### PR TITLE
[hipBLASLt] Add support for non-temporal MXFP4 custom kernels

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels.cpp
@@ -333,145 +333,145 @@ void preloadCustomKernels(SolutionCache& cache)
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));            
 
-                params.workgroupTile    = {128, 256, 256};
-                cache.addKernel(
+            params.workgroupTile    = {128, 256, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                params.workgroupTile    = {128, 384, 256};
-                cache.addKernel(
+            params.workgroupTile    = {128, 384, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                params.workgroupTile    = {128, 512, 256};
-                cache.addKernel(
+            params.workgroupTile    = {128, 512, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                // 160xN kernels
-                params.workgroupTile    = {160, 128, 256};
-                cache.addKernel(
+            // 160xN kernels
+            params.workgroupTile    = {160, 128, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                params.workgroupTile    = {160, 256, 256};
-                cache.addKernel(
+            params.workgroupTile    = {160, 256, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                params.workgroupTile    = {160, 384, 256};
-                cache.addKernel(
+            params.workgroupTile    = {160, 384, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                // 192xN kernels
-                params.workgroupTile    = {192, 128, 256};
-                cache.addKernel(
+            // 192xN kernels
+            params.workgroupTile    = {192, 128, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                params.workgroupTile    = {192, 256, 256};
-                cache.addKernel(
+            params.workgroupTile    = {192, 256, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                // 224xN kernels
-                params.workgroupTile    = {224, 128, 256};
-                cache.addKernel(
+            // 224xN kernels
+            params.workgroupTile    = {224, 128, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                params.workgroupTile    = {224, 256, 256};
-                cache.addKernel(
+            params.workgroupTile    = {224, 256, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
-                // 256xN kernels
-                params.workgroupTile    = {256, 128, 256};
-                cache.addKernel(
+            // 256xN kernels
+            params.workgroupTile    = {256, 128, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
-                    params,
-                    createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128", nonTemporalA, nonTemporalB),
-                        mxfp4Kernel,
-                        params.workgroupTile,
-                        getCoPath() / "rr_custom_kernels.co"));
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
 
+            params.workgroupTile    = {256, 256, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            // No B pre-shuffle variant (only for non-ntA)
+            if (!nonTemporalA && !nonTemporalB)
+            {
+                mxfp4Kernel.swizzleA    = false;
                 params.workgroupTile    = {256, 256, 256};
                 cache.addKernel(
                     mxfp4Kernel,
                     params,
                     createCustomGemmKernel(
-                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256", nonTemporalA, nonTemporalB),
+                        "f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256",
                         mxfp4Kernel,
                         params.workgroupTile,
                         getCoPath() / "rr_custom_kernels.co"));
-
-                // No B pre-shuffle variant (only for non-ntA)
-                if (!nonTemporalA)
-                {
-                    mxfp4Kernel.swizzleA    = false;
-                    params.workgroupTile    = {256, 256, 256};
-                    cache.addKernel(
-                        mxfp4Kernel,
-                        params,
-                        createCustomGemmKernel(
-                            "f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256",
-                            mxfp4Kernel,
-                            params.workgroupTile,
-                            getCoPath() / "rr_custom_kernels.co"));
-                    mxfp4Kernel.swizzleA = true; // Reset for next iteration
-                }
+                mxfp4Kernel.swizzleA = true; // Reset for next iteration
+            }
         }
     }
 }

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels.cpp
@@ -59,6 +59,17 @@ std::filesystem::path getCoPath()
     return libraryPath;
 }
 
+// Helper to get kernel name with optional _ntA or _ntB suffix
+// Note: Currently only supports either _ntA or _ntB, not both simultaneously
+std::string getKernelName(const std::string& baseName, bool nonTemporalA, bool nonTemporalB)
+{
+    if (nonTemporalA)
+        return baseName + "_ntA";
+    if (nonTemporalB)
+        return baseName + "_ntB";
+    return baseName;
+}
+
 // Add all custom kernels to the SolutionCache
 // Need to specify the KernelType and SolutionIndexParameters
 void preloadCustomKernels(SolutionCache& cache)
@@ -85,365 +96,382 @@ void preloadCustomKernels(SolutionCache& cache)
    
     for (bool workgroupMapping : {false, true})
     {
-        params.streamK = false;
-        params.tailLoops = true;
-        params.workgroupMapping = workgroupMapping;
-
-        mxfp4Kernel.swizzleA = true;
-
-        // 32xN kernels
-        params.workgroupTile    = {32, 128, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 256, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 384, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 512, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 640, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 768, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 896, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {32, 1024, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 256, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 384, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 512, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 640, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 768, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 896, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {64, 1024, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        // 96xN kernels
-        params.workgroupTile    = {96, 128, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {96, 256, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {96, 384, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {96, 512, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        params.workgroupTile    = {96, 640, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        // 128xN kernels
-        params.workgroupTile    = {128, 128, 256};
-        cache.addKernel(
-            mxfp4Kernel,
-            params,
-            createCustomGemmKernel(
-                "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E",
-                mxfp4Kernel,
-                params.workgroupTile,
-                getCoPath() / "rr_custom_kernels.co"));
-
-        for (bool streamK : {false, true})
+        // Iterate over nonTemporal combinations: (false,false), (true,false), (false,true)
+        // Note: (true,true) would need _ntAB kernels which we don't have
+        for (auto [nonTemporalA, nonTemporalB] : std::initializer_list<std::pair<bool,bool>>{{false,false}, {true,false}, {false,true}})
         {
-            params.streamK = streamK;
+            params.streamK = false;
+            params.tailLoops = true;
+            params.workgroupMapping = workgroupMapping;
+            params.nonTemporalA = nonTemporalA;
+            params.nonTemporalB = nonTemporalB;
 
-            params.workgroupTile    = {128, 256, 256};
+            mxfp4Kernel.swizzleA = true;
+
+            // 32xN kernels
+            params.workgroupTile    = {32, 128, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {128, 384, 256};
+            params.workgroupTile    = {32, 256, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {128, 512, 256};
+            params.workgroupTile    = {32, 384, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            // 160xN kernels
-            params.workgroupTile    = {160, 128, 256};
+            params.workgroupTile    = {32, 512, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {160, 256, 256};
+            params.workgroupTile    = {32, 640, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {160, 384, 256};
+            params.workgroupTile    = {32, 768, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            // 192xN kernels
-            params.workgroupTile    = {192, 128, 256};
+            params.workgroupTile    = {32, 896, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {192, 256, 256};
+            params.workgroupTile    = {32, 1024, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            // 224xN kernels
-            params.workgroupTile    = {224, 128, 256};
+            // 64xN kernels
+            params.workgroupTile    = {64, 128, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {224, 256, 256};
+            params.workgroupTile    = {64, 256, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            // 256xN kernels
-            params.workgroupTile    = {256, 128, 256};
+
+            params.workgroupTile    = {64, 384, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            params.workgroupTile    = {256, 256, 256};
+            params.workgroupTile    = {64, 512, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
 
-            // No B pre-shuffle
-            mxfp4Kernel.swizzleA    = false;
-            params.workgroupTile    = {256, 256, 256};
+            params.workgroupTile    = {64, 640, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
                 createCustomGemmKernel(
-                    "_ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E",
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));
-            mxfp4Kernel.swizzleA    = true;
+
+            params.workgroupTile    = {64, 768, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            params.workgroupTile    = {64, 896, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            params.workgroupTile    = {64, 1024, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            // 96xN kernels
+            params.workgroupTile    = {96, 128, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            params.workgroupTile    = {96, 256, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            params.workgroupTile    = {96, 384, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            params.workgroupTile    = {96, 512, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            params.workgroupTile    = {96, 640, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));
+
+            // 128xN kernels
+            params.workgroupTile    = {128, 128, 256};
+            cache.addKernel(
+                mxfp4Kernel,
+                params,
+                createCustomGemmKernel(
+                    getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128", nonTemporalA, nonTemporalB),
+                    mxfp4Kernel,
+                    params.workgroupTile,
+                    getCoPath() / "rr_custom_kernels.co"));            
+
+                params.workgroupTile    = {128, 256, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {128, 384, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {128, 512, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                // 160xN kernels
+                params.workgroupTile    = {160, 128, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {160, 256, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {160, 384, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                // 192xN kernels
+                params.workgroupTile    = {192, 128, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {192, 256, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                // 224xN kernels
+                params.workgroupTile    = {224, 128, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {224, 256, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                // 256xN kernels
+                params.workgroupTile    = {256, 128, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                params.workgroupTile    = {256, 256, 256};
+                cache.addKernel(
+                    mxfp4Kernel,
+                    params,
+                    createCustomGemmKernel(
+                        getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256", nonTemporalA, nonTemporalB),
+                        mxfp4Kernel,
+                        params.workgroupTile,
+                        getCoPath() / "rr_custom_kernels.co"));
+
+                // No B pre-shuffle variant (only for non-ntA)
+                if (!nonTemporalA)
+                {
+                    mxfp4Kernel.swizzleA    = false;
+                    params.workgroupTile    = {256, 256, 256};
+                    cache.addKernel(
+                        mxfp4Kernel,
+                        params,
+                        createCustomGemmKernel(
+                            "f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256",
+                            mxfp4Kernel,
+                            params.workgroupTile,
+                            getCoPath() / "rr_custom_kernels.co"));
+                    mxfp4Kernel.swizzleA = true; // Reset for next iteration
+                }
         }
     }
 }

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/CMakeLists.txt
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/CMakeLists.txt
@@ -23,40 +23,117 @@ file(MAKE_DIRECTORY "${BUILT_OBJ_DIR}")
 
 # Assembly source files for custom kernels (explicit list)
 set(CUSTOM_KERNEL_ASM_SOURCES
+    # 32xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB.s
+    # 64xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB.s
+    # 96xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB.s
+    # 128xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB.s
+    # 160xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB.s
+    # 192xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB.s
+    # 224xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB.s
+    # 256xN kernels
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB.s
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA.s
+    ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB.s
+    # No B pre-shuffle variant
     ${CMAKE_CURRENT_SOURCE_DIR}/f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256.s
 )
 

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1541,7 +1541,7 @@ label_0B8D:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1988,14 +1988,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA.s
@@ -1,0 +1,2006 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x7f                                   
+	s_lshr_b32 s62, s51, 7                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_003A:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003F                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_003A                                        
+	
+label_003F:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0045                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0065                                        
+	
+label_0045:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0065:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	v_add_u32_e32 v146, s62, v145                              
+	v_add_u32_e32 v147, s62, v146                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v148, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v148, v5, v148                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v148, v6, v148                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v148, v4, v148                               
+	v_add_u32_e32 v148, 0x1000, v148                           
+	v_add_u32_e32 v149, 0x4200, v148                           
+	v_add_u32_e32 v150, 0x4200, v149                           
+	v_add_u32_e32 v151, 0x4200, v150                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v152, s63, v152                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v153, 2, v0                              
+	v_add_u32_e32 v153, 0, v153                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v154, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v154, s62, v154                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v155, s62, v154                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v156, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v156, s63, v156                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(27)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v148                                 
+	ds_read_b128 v[16:19], v148 offset:64                      
+	ds_read_b128 v[12:15], v148 offset:512                     
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v157, s36, v5                                 
+	v_add_u32_e32 v157, s62, v157                              
+	v_add_u32_e32 v157, v4, v157                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_05EA                                  
+	
+label_0257:
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[40:43], a[32:35], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[44:47], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[40:43], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[44:47], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[48:51], a[32:35], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[52:55], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[48:51], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[52:55], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[56:59], a[48:51], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[60:63], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[56:59], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[60:63], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[64:67], a[48:51], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[68:71], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[64:67], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[68:71], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:1280                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:2304                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:3328                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_branch label_0257                                        
+	
+label_05EA:
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[40:43], a[32:35], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[44:47], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[40:43], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[44:47], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[48:51], a[32:35], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[52:55], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[48:51], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[52:55], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	ds_read_b32 v136, v153 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[56:59], a[48:51], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[60:63], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[56:59], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[60:63], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[64:67], a[48:51], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[68:71], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[64:67], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[68:71], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	ds_read_b32 v137, v153 offset:1280                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	ds_read_b32 v136, v153 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	ds_read_b32 v137, v153 offset:2304                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	ds_read_b32 v136, v153 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	ds_read_b32 v137, v153 offset:3328                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_branch label_05EA                                        
+	
+label_097D:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0A88                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	s_branch label_0B8D                                        
+	
+label_0A88:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0B8D                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	
+label_0B8D:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB.s
@@ -1,0 +1,2006 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x7f                                   
+	s_lshr_b32 s62, s51, 7                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_003A:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003F                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_003A                                        
+	
+label_003F:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0045                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0065                                        
+	
+label_0045:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0065:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	v_add_u32_e32 v146, s62, v145                              
+	v_add_u32_e32 v147, s62, v146                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v148, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v148, v5, v148                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v148, v6, v148                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v148, v4, v148                               
+	v_add_u32_e32 v148, 0x1000, v148                           
+	v_add_u32_e32 v149, 0x4200, v148                           
+	v_add_u32_e32 v150, 0x4200, v149                           
+	v_add_u32_e32 v151, 0x4200, v150                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v152, s63, v152                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v153, 2, v0                              
+	v_add_u32_e32 v153, 0, v153                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v154, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v154, s62, v154                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v155, s62, v154                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v156, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v156, s63, v156                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(27)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v148                                 
+	ds_read_b128 v[16:19], v148 offset:64                      
+	ds_read_b128 v[12:15], v148 offset:512                     
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v157, s36, v5                                 
+	v_add_u32_e32 v157, s62, v157                              
+	v_add_u32_e32 v157, v4, v157                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_05EA                                  
+	
+label_0257:
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[40:43], a[32:35], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[44:47], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[40:43], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[44:47], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[48:51], a[32:35], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[52:55], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[48:51], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[52:55], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[56:59], a[48:51], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[60:63], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[56:59], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[60:63], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[64:67], a[48:51], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[68:71], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[64:67], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[68:71], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:1280                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:2304                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:3328                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_branch label_0257                                        
+	
+label_05EA:
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[40:43], a[32:35], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[44:47], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[40:43], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[44:47], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[48:51], a[32:35], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[52:55], a[36:39], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[48:51], a[40:43], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[52:55], a[44:47], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	ds_read_b32 v136, v153 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[56:59], a[48:51], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[60:63], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[56:59], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[60:63], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[64:67], a[48:51], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[68:71], a[52:55], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[64:67], a[56:59], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[68:71], a[60:63], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	ds_read_b32 v137, v153 offset:1280                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	ds_read_b32 v136, v153 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	ds_read_b32 v137, v153 offset:2304                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	ds_read_b32 v136, v153 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	ds_read_b32 v137, v153 offset:3328                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_waitcnt vmcnt(20) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt vmcnt(23) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_097D                                  
+	s_branch label_05EA                                        
+	
+label_097D:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0A88                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	s_branch label_0B8D                                        
+	
+label_0A88:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0B8D                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	
+label_0B8D:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2190,7 +2190,7 @@ label_1241:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2637,14 +2637,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA.s
@@ -1,0 +1,2655 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x7f                                   
+	s_lshr_b32 s62, s51, 7                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_003A:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003F                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_003A                                        
+	
+label_003F:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0045                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0065                                        
+	
+label_0045:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0065:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	v_add_u32_e32 v146, s62, v145                              
+	v_add_u32_e32 v147, s62, v146                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v148, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v148, v5, v148                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v148, v6, v148                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v148, v4, v148                               
+	v_add_u32_e32 v148, 0x1000, v148                           
+	v_add_u32_e32 v149, 0x4200, v148                           
+	v_add_u32_e32 v150, 0x4200, v149                           
+	v_add_u32_e32 v151, 0x4200, v150                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v152, s63, v152                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v153, 2, v0                              
+	v_add_u32_e32 v153, 0, v153                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v154, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v154, s62, v154                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v155, s62, v154                              
+	v_add_u32_e32 v156, s62, v155                              
+	v_add_u32_e32 v157, s62, v156                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v158, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v158, s63, v158                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v159, s62, v158                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v158, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v148                                 
+	ds_read_b128 v[16:19], v148 offset:64                      
+	ds_read_b128 v[12:15], v148 offset:512                     
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v160, s36, v5                                 
+	v_add_u32_e32 v160, s62, v160                              
+	v_add_u32_e32 v160, v4, v160                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0869                                  
+	
+label_02A6:
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:1280                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:2304                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:3328                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:256                          
+	s_cbranch_scc0 label_0E2C                                  
+	s_branch label_02A6                                        
+	
+label_0869:
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	ds_read_b32 v136, v153 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	ds_read_b32 v137, v153 offset:1280                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	ds_read_b32 v136, v153 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	ds_read_b32 v137, v153 offset:2304                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	ds_read_b32 v136, v153 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	ds_read_b32 v137, v153 offset:3328                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_cbranch_scc0 label_0E2C                                  
+	s_branch label_0869                                        
+	
+label_0E2C:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_1038                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v164, 0, v160                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_add_u32_e32 v164, 64, v160                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	s_branch label_1241                                        
+	
+label_1038:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1241                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v164, 0, v160                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1241                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v164, 64, v160                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	
+label_1241:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB.s
@@ -1,0 +1,2655 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x7f                                   
+	s_lshr_b32 s62, s51, 7                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_003A:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003F                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_003A                                        
+	
+label_003F:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0045                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0065                                        
+	
+label_0045:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0065:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	v_add_u32_e32 v146, s62, v145                              
+	v_add_u32_e32 v147, s62, v146                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v148, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v148, v5, v148                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v148, v6, v148                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v148, v4, v148                               
+	v_add_u32_e32 v148, 0x1000, v148                           
+	v_add_u32_e32 v149, 0x4200, v148                           
+	v_add_u32_e32 v150, 0x4200, v149                           
+	v_add_u32_e32 v151, 0x4200, v150                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v152, s63, v152                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v153, 2, v0                              
+	v_add_u32_e32 v153, 0, v153                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v154, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v154, s62, v154                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v155, s62, v154                              
+	v_add_u32_e32 v156, s62, v155                              
+	v_add_u32_e32 v157, s62, v156                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v158, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v158, s63, v158                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v159, s62, v158                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v158, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v148                                 
+	ds_read_b128 v[16:19], v148 offset:64                      
+	ds_read_b128 v[12:15], v148 offset:512                     
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v160, s36, v5                                 
+	v_add_u32_e32 v160, s62, v160                              
+	v_add_u32_e32 v160, v4, v160                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0869                                  
+	
+label_02A6:
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:1280                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:2304                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:3328                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v136, v153                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v153 offset:256                          
+	s_cbranch_scc0 label_0E2C                                  
+	s_branch label_02A6                                        
+	
+label_0869:
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v148 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v148 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v148 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v148 offset:9024                    
+	ds_read_b32 v138, v153 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:13248                   
+	ds_read_b32 v139, v153 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v149                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v149 offset:576                     
+	ds_read_b32 v136, v153 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v149 offset:4800                    
+	ds_read_b32 v137, v153 offset:1280                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v149 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v149 offset:9024                    
+	ds_read_b32 v138, v153 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v149 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v149 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v149 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v149 offset:13248                   
+	ds_read_b32 v139, v153 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v150                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v150 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v150 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v150 offset:576                     
+	ds_read_b32 v136, v153 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v150 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v150 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v150 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v150 offset:4800                    
+	ds_read_b32 v137, v153 offset:2304                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v150 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v150 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v150 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v150 offset:9024                    
+	ds_read_b32 v138, v153 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v150 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v150 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v150 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v150 offset:13248                   
+	ds_read_b32 v139, v153 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[40:43], a[64:67], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[44:47], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[40:43], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[44:47], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[48:51], a[64:67], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[52:55], a[68:71], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[48:51], a[72:75], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[52:55], a[76:79], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[72:75], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[40:43], a[80:83], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[44:47], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v151                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[40:43], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[44:47], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v151 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[48:51], a[80:83], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[52:55], a[84:87], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v151 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[48:51], a[88:91], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[52:55], a[92:95], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v151 offset:576                     
+	ds_read_b32 v136, v153 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v151 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v151 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v151 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v151 offset:4800                    
+	ds_read_b32 v137, v153 offset:3328                         
+	s_cbranch_scc0 label_0E2C                                  
+	s_waitcnt vmcnt(15) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v156, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v151 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v151 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v157, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v151 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v151 offset:9024                    
+	ds_read_b32 v138, v153 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v151 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v151 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v151 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v151 offset:13248                   
+	ds_read_b32 v139, v153 offset:3840                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v152, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v146, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v147, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v153                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v153 offset:256                          
+	s_cbranch_scc0 label_0E2C                                  
+	s_branch label_0869                                        
+	
+label_0E2C:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_1038                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v164, 0, v160                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_add_u32_e32 v164, 64, v160                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	s_branch label_1241                                        
+	
+label_1038:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1241                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v164, 0, v160                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1241                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v164, 64, v160                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v164, s[4:7], 0 offen       
+	v_add_u32_e32 v164, s62, v164                              
+	
+label_1241:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2181,7 +2181,7 @@ label_1134:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2628,14 +2628,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA.s
@@ -1,0 +1,2646 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x7f                                   
+	s_lshr_b32 s62, s51, 7                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v182, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v182, v5, v182                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v182, v6, v182                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v182, v4, v182                               
+	v_add_u32_e32 v182, 0x800, v182                            
+	v_add_u32_e32 v183, 0x4200, v182                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v184, s63, v184                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v185, 2, v0                              
+	v_add_u32_e32 v185, 0, v185                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v186, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v186, s62, v186                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v192, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v192, s63, v192                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v193, s62, v192                              
+	v_add_u32_e32 v194, s62, v193                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v186, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v187, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v172, v192, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v188, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[92:95], v189, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[96:99], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[100:103], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dword v173, v193, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[104:107], v190, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[108:111], v191, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[112:115], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dwordx4 v[116:119], v191, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	buffer_load_dword v174, v194, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v182                                 
+	ds_read_b128 v[16:19], v182 offset:64                      
+	ds_read_b128 v[12:15], v182 offset:512                     
+	ds_read_b128 v[20:23], v182 offset:576                     
+	ds_read_b32 v168, v185                                     
+	ds_read_b128 v[24:27], v182 offset:4224                    
+	ds_read_b128 v[32:35], v182 offset:4288                    
+	ds_read_b128 v[28:31], v182 offset:4736                    
+	ds_read_b128 v[36:39], v182 offset:4800                    
+	ds_read_b32 v169, v185 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v195, s36, v5                                 
+	v_add_u32_e32 v195, s62, v195                              
+	v_add_u32_e32 v195, v4, v195                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_071F                                  
+	
+label_0328:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v182 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v185 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v185 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[40:43], a[96:99], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[44:47], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[40:43], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[44:47], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[48:51], a[96:99], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[52:55], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[48:51], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[52:55], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[72:75], v[56:59], a[144:147], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[72:75], v[60:63], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[56:59], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[60:63], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[80:83], v[64:67], a[144:147], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[80:83], v[68:71], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[84:87], v[64:67], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[84:87], v[68:71], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[136:139], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[40:43], a[112:115], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[44:47], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[40:43], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[44:47], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[48:51], a[112:115], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[52:55], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[48:51], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[52:55], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[88:91], v[56:59], a[160:163], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[88:91], v[60:63], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[92:95], v[56:59], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[92:95], v[60:63], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[64:67], a[160:163], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[68:71], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[100:103], v[64:67], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[100:103], v[68:71], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v183 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v185 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[104:107], v[56:59], a[176:179], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[104:107], v[60:63], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[108:111], v[56:59], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[108:111], v[60:63], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[112:115], v[64:67], a[176:179], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[112:115], v[68:71], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[116:119], v[64:67], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[116:119], v[68:71], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v185 offset:1280                         
+	s_cbranch_scc0 label_0B16                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v185 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v183 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v183 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v183 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v183 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v185 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[40:43], a[96:99], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[44:47], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[40:43], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[44:47], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[48:51], a[96:99], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[52:55], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[48:51], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[52:55], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v189, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[40:43], a[112:115], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[44:47], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[40:43], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[44:47], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[48:51], a[112:115], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[52:55], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[48:51], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[52:55], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[8:11], a[32:35], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[12:15], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[104:107], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[8:11], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[12:15], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[16:19], a[32:35], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[20:23], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[16:19], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[20:23], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[40:43], a[128:131], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v182                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[44:47], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[40:43], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[44:47], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[48:51], a[128:131], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[52:55], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[48:51], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[52:55], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v185                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v185 offset:256                          
+	s_cbranch_scc0 label_0B16                                  
+	s_branch label_0328                                        
+	
+label_071F:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v182 offset:9024                    
+	ds_read_b32 v170, v185 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:13248                   
+	ds_read_b32 v171, v185 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[40:43], a[96:99], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[44:47], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[40:43], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[44:47], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[48:51], a[96:99], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[52:55], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[48:51], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[52:55], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[72:75], v[56:59], a[144:147], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[72:75], v[60:63], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[56:59], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[60:63], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[80:83], v[64:67], a[144:147], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[80:83], v[68:71], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[84:87], v[64:67], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[84:87], v[68:71], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[136:139], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[40:43], a[112:115], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[44:47], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[40:43], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[44:47], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[48:51], a[112:115], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[52:55], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[48:51], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[52:55], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[88:91], v[56:59], a[160:163], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[88:91], v[60:63], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[92:95], v[56:59], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[92:95], v[60:63], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[64:67], a[160:163], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[68:71], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[100:103], v[64:67], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[100:103], v[68:71], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v183 offset:576                     
+	ds_read_b32 v168, v185 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[104:107], v[56:59], a[176:179], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[104:107], v[60:63], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[108:111], v[56:59], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[108:111], v[60:63], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[112:115], v[64:67], a[176:179], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[112:115], v[68:71], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[116:119], v[64:67], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[116:119], v[68:71], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	ds_read_b32 v169, v185 offset:1280                         
+	s_cbranch_scc0 label_0B16                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	ds_read_b32 v170, v185 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v183 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v183 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v183 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v183 offset:13248                   
+	ds_read_b32 v171, v185 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[40:43], a[96:99], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[44:47], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[40:43], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[44:47], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[48:51], a[96:99], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[52:55], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[48:51], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[52:55], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v189, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[40:43], a[112:115], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[44:47], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[40:43], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[44:47], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[48:51], a[112:115], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[52:55], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[48:51], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[52:55], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[8:11], a[32:35], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[12:15], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[8:11], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[12:15], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[16:19], a[32:35], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[20:23], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[16:19], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[20:23], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[40:43], a[128:131], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[44:47], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v182                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[40:43], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[44:47], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[48:51], a[128:131], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[52:55], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[48:51], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[52:55], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v182 offset:576                     
+	ds_read_b32 v168, v185                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v182 offset:4800                    
+	ds_read_b32 v169, v185 offset:256                          
+	s_cbranch_scc0 label_0B16                                  
+	s_branch label_071F                                        
+	
+label_0B16:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0E26                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v199, 0, v195                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_add_u32_e32 v199, 64, v195                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_add_u32_e32 v199, 0x80, v195                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	s_branch label_1134                                        
+	
+label_0E26:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1134                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v199, 0, v195                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1134                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v199, 64, v195                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1134                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v199, 0x80, v195                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	
+label_1134:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB.s
@@ -1,0 +1,2646 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x7f                                   
+	s_lshr_b32 s62, s51, 7                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v182, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v182, v5, v182                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v182, v6, v182                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v182, v4, v182                               
+	v_add_u32_e32 v182, 0x800, v182                            
+	v_add_u32_e32 v183, 0x4200, v182                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v184, s63, v184                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v185, 2, v0                              
+	v_add_u32_e32 v185, 0, v185                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v186, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v186, s62, v186                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v192, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v192, s63, v192                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v193, s62, v192                              
+	v_add_u32_e32 v194, s62, v193                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v186, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v187, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v172, v192, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v188, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[92:95], v189, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[96:99], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[100:103], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dword v173, v193, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[104:107], v190, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[108:111], v191, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[112:115], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dwordx4 v[116:119], v191, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	buffer_load_dword v174, v194, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v182                                 
+	ds_read_b128 v[16:19], v182 offset:64                      
+	ds_read_b128 v[12:15], v182 offset:512                     
+	ds_read_b128 v[20:23], v182 offset:576                     
+	ds_read_b32 v168, v185                                     
+	ds_read_b128 v[24:27], v182 offset:4224                    
+	ds_read_b128 v[32:35], v182 offset:4288                    
+	ds_read_b128 v[28:31], v182 offset:4736                    
+	ds_read_b128 v[36:39], v182 offset:4800                    
+	ds_read_b32 v169, v185 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v195, s36, v5                                 
+	v_add_u32_e32 v195, s62, v195                              
+	v_add_u32_e32 v195, v4, v195                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_071F                                  
+	
+label_0328:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v182 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v185 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v185 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[40:43], a[96:99], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[44:47], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[40:43], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[44:47], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[48:51], a[96:99], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[52:55], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[48:51], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[52:55], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[72:75], v[56:59], a[144:147], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[72:75], v[60:63], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[56:59], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[60:63], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[80:83], v[64:67], a[144:147], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[80:83], v[68:71], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[84:87], v[64:67], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[84:87], v[68:71], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[136:139], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[40:43], a[112:115], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[44:47], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[40:43], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[44:47], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[48:51], a[112:115], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[52:55], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[48:51], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[52:55], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[88:91], v[56:59], a[160:163], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[88:91], v[60:63], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[92:95], v[56:59], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[92:95], v[60:63], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[64:67], a[160:163], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[68:71], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[100:103], v[64:67], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[100:103], v[68:71], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v183 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v185 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[104:107], v[56:59], a[176:179], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[104:107], v[60:63], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[108:111], v[56:59], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[108:111], v[60:63], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[112:115], v[64:67], a[176:179], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[112:115], v[68:71], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[116:119], v[64:67], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[116:119], v[68:71], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v185 offset:1280                         
+	s_cbranch_scc0 label_0B16                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v185 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v183 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v183 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v183 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v183 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v185 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[40:43], a[96:99], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[44:47], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[40:43], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[44:47], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[48:51], a[96:99], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[52:55], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[48:51], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[52:55], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v189, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[40:43], a[112:115], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[44:47], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[40:43], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[44:47], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[48:51], a[112:115], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[52:55], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[48:51], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[52:55], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[8:11], a[32:35], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[12:15], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[104:107], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[8:11], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[12:15], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[16:19], a[32:35], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[20:23], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[16:19], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[20:23], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[40:43], a[128:131], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v182                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[44:47], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[40:43], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[44:47], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[48:51], a[128:131], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[52:55], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[48:51], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[52:55], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v185                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v185 offset:256                          
+	s_cbranch_scc0 label_0B16                                  
+	s_branch label_0328                                        
+	
+label_071F:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v182 offset:9024                    
+	ds_read_b32 v170, v185 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:13248                   
+	ds_read_b32 v171, v185 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[40:43], a[96:99], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[44:47], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[40:43], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[44:47], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[48:51], a[96:99], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[52:55], a[100:103], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[48:51], a[104:107], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[52:55], a[108:111], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[72:75], v[56:59], a[144:147], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[72:75], v[60:63], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[56:59], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[60:63], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[80:83], v[64:67], a[144:147], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[80:83], v[68:71], a[148:151], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[84:87], v[64:67], a[152:155], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[84:87], v[68:71], a[156:159], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[136:139], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[40:43], a[112:115], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[44:47], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[40:43], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[44:47], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[48:51], a[112:115], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[52:55], a[116:119], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[48:51], a[120:123], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[52:55], a[124:127], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[88:91], v[56:59], a[160:163], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[88:91], v[60:63], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[92:95], v[56:59], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[92:95], v[60:63], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[64:67], a[160:163], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[68:71], a[164:167], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[100:103], v[64:67], a[168:171], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[100:103], v[68:71], a[172:175], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v183 offset:576                     
+	ds_read_b32 v168, v185 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[104:107], v[56:59], a[176:179], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[104:107], v[60:63], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[108:111], v[56:59], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[108:111], v[60:63], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[112:115], v[64:67], a[176:179], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[112:115], v[68:71], a[180:183], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[116:119], v[64:67], a[184:187], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[116:119], v[68:71], a[188:191], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	ds_read_b32 v169, v185 offset:1280                         
+	s_cbranch_scc0 label_0B16                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v184, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	ds_read_b32 v170, v185 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v183 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v183 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v183 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v183 offset:13248                   
+	ds_read_b32 v171, v185 offset:1792                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[40:43], a[96:99], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[44:47], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[40:43], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[44:47], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[48:51], a[96:99], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[52:55], a[100:103], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[48:51], a[104:107], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[52:55], a[108:111], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v189, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[40:43], a[112:115], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[44:47], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[40:43], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[44:47], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[48:51], a[112:115], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[52:55], a[116:119], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[48:51], a[120:123], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[52:55], a[124:127], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[8:11], a[32:35], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[12:15], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[8:11], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[12:15], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[16:19], a[32:35], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[20:23], a[36:39], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[16:19], a[40:43], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[20:23], a[44:47], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[40:43], a[128:131], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[44:47], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v182                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[40:43], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[44:47], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[48:51], a[128:131], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[52:55], a[132:135], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[48:51], a[136:139], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[52:55], a[140:143], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v182 offset:576                     
+	ds_read_b32 v168, v185                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v182 offset:4800                    
+	ds_read_b32 v169, v185 offset:256                          
+	s_cbranch_scc0 label_0B16                                  
+	s_branch label_071F                                        
+	
+label_0B16:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0E26                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v199, 0, v195                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_add_u32_e32 v199, 64, v195                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_add_u32_e32 v199, 0x80, v195                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	s_branch label_1134                                        
+	
+label_0E26:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1134                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v199, 0, v195                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1134                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v199, 64, v195                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1134                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v199, 0x80, v195                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	v_add_u32_e32 v199, s62, v199                              
+	
+label_1134:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x384_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_mov_b32 s47, s2                                          
@@ -3686,7 +3686,7 @@ label_1BA0:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -4133,14 +4133,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA.s
@@ -1,0 +1,4151 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	s_mov_b32 s64, s4                                          
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	s_load_dword s65, s[0:1], 0x170                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_mov_b32 s6, -16                                          
+	s_mov_b32 s10, -16                                         
+	s_mov_b32 s18, -16                                         
+	s_mov_b32 s14, -16                                         
+	s_mov_b32 s22, -16                                         
+	s_mov_b32 s26, -16                                         
+	s_mov_b32 s7, 0x20000                                      
+	s_mov_b32 s11, 0x20000                                     
+	s_mov_b32 s19, 0x20000                                     
+	s_mov_b32 s15, 0x20000                                     
+	s_mov_b32 s23, 0x20000                                     
+	s_mov_b32 s27, 0x20000                                     
+	s_and_b32 s5, s5, 0xffff                                   
+	s_and_b32 s9, s9, 0xffff                                   
+	s_and_b32 s17, s17, 0xffff                                 
+	s_and_b32 s13, s13, 0xffff                                 
+	s_and_b32 s21, s21, 0xffff                                 
+	s_and_b32 s25, s25, 0xffff                                 
+	s_or_b32 s5, s5, 0x40000                                   
+	s_or_b32 s9, s9, 0x40000                                   
+	s_or_b32 s17, s17, 0x40000                                 
+	s_or_b32 s13, s13, 0x40000                                 
+	s_or_b32 s21, s21, 0x40000                                 
+	s_or_b32 s25, s25, 0x40000                                 
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_0068                                  
+	s_lshr_b32 s66, s45, s65                                   
+	s_add_u32 s66, s66, 0xff                                   
+	s_lshr_b32 s66, s66, 8                                     
+	s_lshl_b32 s66, s66, 8                                     
+	s_mul_i32 s63, s66, s64                                    
+	s_sub_i32 s62, s45, s63                                    
+	s_cmp_lt_i32 s62, s66                                      
+	s_cselect_b32 s45, s62, s66                                
+	
+label_0068:
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s63, s37, s62                                    
+	s_mov_b32 s14, s63                                         
+	s_mov_b32 s15, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_0080                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_lshr_b32 s62, s63, 1                                     
+	s_add_u32 s12, s12, s62                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_u32 s14, s14, s62                                    
+	
+label_0080:
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	s_mul_i32 s67, 0x420, s46                                  
+	s_add_u32 s67, 0x800, s67                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v216, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v216, v5, v216                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v216, v6, v216                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v216, v4, v216                               
+	s_mov_b32 s62, 0x800                                       
+	v_add_u32_e64 v216, v216, s62                              
+	v_add_u32_e32 v217, 0x4200, v216                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s63, s39, s62                                    
+	s_mov_b32 s22, s63                                         
+	s_mov_b32 s23, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_00D0                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_sub_u32 s22, s22, s63                                    
+	
+label_00D0:
+	v_lshlrev_b32_e32 v218, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v218, s63, v218                              
+	s_mul_i32 s68, s46, 0x100                                  
+	s_add_i32 s68, s68, 0                                      
+	v_lshlrev_b32_e32 v219, 2, v0                              
+	v_add_u32_e32 v219, 0, v219                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s63, s38, s62                                    
+	s_mov_b32 s18, s63                                         
+	s_mov_b32 s19, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_00F2                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_lshr_b32 s62, s63, 1                                     
+	s_mul_i32 s62, s62, 16                                     
+	s_add_u32 s16, s16, s62                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_u32 s18, s18, s62                                    
+	
+label_00F2:
+	v_lshlrev_b32_e32 v220, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v220, s62, v220                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, 0x400, v220                            
+	v_add_u32_e32 v225, 0x400, v221                            
+	v_add_u32_e32 v226, 0x400, v222                            
+	v_add_u32_e32 v227, 0x400, v223                            
+	s_mul_i32 s62, 64, s38                                     
+	v_add_u32_e32 v228, s62, v220                              
+	v_add_u32_e32 v229, s62, v221                              
+	v_add_u32_e32 v230, s62, v222                              
+	v_add_u32_e32 v231, s62, v223                              
+	v_add_u32_e32 v232, s62, v224                              
+	v_add_u32_e32 v233, s62, v225                              
+	v_add_u32_e32 v234, s62, v226                              
+	v_add_u32_e32 v235, s62, v227                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s63, s40, s62                                    
+	s_mov_b32 s26, s63                                         
+	s_mov_b32 s27, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_0122                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_u32 s26, s26, s63                                    
+	
+label_0122:
+	v_lshlrev_b32_e32 v236, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v236, s63, v236                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	s_mov_b32 s69, 0x80                                        
+	s_mov_b32 s70, 0x800                                       
+	s_mov_b32 s71, 0x100                                       
+	s_mov_b32 s72, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s67                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x1080, s67                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0, s68                                       
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s67                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0x3180, s67                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	s_add_u32 s12, s12, s69                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s69                                    
+	s_add_u32 s20, s20, s71                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s71                                    
+	buffer_load_dwordx4 v[72:75], v220, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[76:79], v221, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	buffer_load_dwordx4 v[80:83], v222, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	buffer_load_dwordx4 v[84:87], v223, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[88:91], v224, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[92:95], v225, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[96:99], v226, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[100:103], v227, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dword v204, v236, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dword v205, v237, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[104:107], v228, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[108:111], v229, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dwordx4 v[112:115], v230, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dwordx4 v[116:119], v231, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	buffer_load_dwordx4 v[120:123], v232, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	buffer_load_dwordx4 v[124:127], v233, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	buffer_load_dwordx4 v[128:131], v234, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	buffer_load_dwordx4 v[132:135], v235, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	buffer_load_dword v206, v238, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	buffer_load_dword v207, v239, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s70, s70, 0                                  
+	s_cselect_b32 s72, s72, 0                                  
+	s_add_u32 s16, s16, s70                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s70                                    
+	s_add_u32 s24, s24, s72                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s72                                    
+	s_add_u32 m0, 0x4200, s67                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	s_add_u32 m0, 0x5280, s67                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	s_add_u32 m0, 0x400, s68                                   
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	s_add_u32 m0, 0x6300, s67                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	s_add_u32 m0, 0x7380, s67                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	v_accvgpr_write_b32 a240, 0                                
+	v_accvgpr_write_b32 a241, 0                                
+	v_accvgpr_write_b32 a242, 0                                
+	v_accvgpr_write_b32 a243, 0                                
+	v_accvgpr_write_b32 a244, 0                                
+	v_accvgpr_write_b32 a245, 0                                
+	v_accvgpr_write_b32 a246, 0                                
+	v_accvgpr_write_b32 a247, 0                                
+	v_accvgpr_write_b32 a248, 0                                
+	v_accvgpr_write_b32 a249, 0                                
+	v_accvgpr_write_b32 a250, 0                                
+	v_accvgpr_write_b32 a251, 0                                
+	v_accvgpr_write_b32 a252, 0                                
+	v_accvgpr_write_b32 a253, 0                                
+	v_accvgpr_write_b32 a254, 0                                
+	v_accvgpr_write_b32 a255, 0                                
+	s_waitcnt vmcnt(27)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v216                                 
+	ds_read_b128 v[24:27], v216 offset:64                      
+	ds_read_b128 v[12:15], v216 offset:512                     
+	ds_read_b128 v[28:31], v216 offset:576                     
+	ds_read_b128 v[16:19], v216 offset:4224                    
+	ds_read_b128 v[32:35], v216 offset:4288                    
+	ds_read_b128 v[20:23], v216 offset:4736                    
+	ds_read_b128 v[36:39], v216 offset:4800                    
+	ds_read_b32 v200, v219                                     
+	ds_read_b32 v201, v219 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s62, s62, s63                                    
+	s_mov_b32 s6, s62                                          
+	s_mov_b32 s7, 0x20000                                      
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_03D8                                  
+	v_mul_i32_i24_e64 v4, v0, 4                                
+	s_mul_i32 s62, s46, 0x100                                  
+	v_add_u32_e32 v240, s62, v4                                
+	v_add_u32_e32 v241, 0x80, v240                             
+	s_mul_i32 s62, s36, 64                                     
+	v_add_u32_e32 v242, s62, v240                              
+	v_add_u32_e32 v243, s62, v241                              
+	s_branch label_03EE                                        
+	
+label_03D8:
+	v_and_b32_e64 v4, v0, 15                                   
+	v_mul_lo_u32 v240, s36, v4                                 
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e64 v4, v4, 16                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e64 v5, v5, 1                                    
+	v_mul_i32_i24_e64 v5, v5, 32                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_add_u32_e32 v240, v4, v240                               
+	s_mul_i32 s62, s46, 0x100                                  
+	v_add_u32_e32 v240, s62, v240                              
+	v_add_u32_e32 v241, 0x80, v240                             
+	s_mul_i32 s62, s36, 64                                     
+	v_add_u32_e32 v242, s62, v240                              
+	v_add_u32_e32 v243, s62, v241                              
+	
+label_03EE:
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_08F4                                  
+	
+label_03F0:
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v220, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[76:79], v[8:11], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[76:79], v[12:15], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[72:75], v[16:19], a[8:11], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[72:75], v[20:23], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v221, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[16:19], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[20:23], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[8:11], a[32:35], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[12:15], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[84:87], v[8:11], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v216 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[84:87], v[12:15], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[80:83], v[16:19], a[40:43], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[80:83], v[20:23], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[16:19], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v216 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[20:23], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[92:95], v[24:27], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[92:95], v[28:31], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[88:91], v[32:35], a[8:11], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[88:91], v[36:39], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[32:35], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[36:39], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[24:27], a[32:35], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[28:31], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[100:103], v[24:27], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[100:103], v[28:31], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[96:99], v[32:35], a[40:43], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[96:99], v[36:39], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[8:11], a[64:67], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[12:15], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[108:111], v[8:11], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[108:111], v[12:15], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[104:107], v[16:19], a[72:75], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[104:107], v[20:23], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[16:19], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[20:23], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[8:11], a[96:99], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[12:15], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[116:119], v[8:11], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[116:119], v[12:15], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[112:115], v[16:19], a[104:107], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[112:115], v[20:23], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[16:19], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[20:23], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[124:127], v[24:27], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[124:127], v[28:31], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[120:123], v[32:35], a[72:75], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[120:123], v[36:39], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[32:35], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[36:39], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[24:27], a[96:99], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[28:31], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[132:135], v[24:27], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[132:135], v[28:31], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[128:131], v[32:35], a[104:107], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[128:131], v[36:39], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[40:43], a[128:131], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[44:47], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[76:79], v[40:43], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v217                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[76:79], v[44:47], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[72:75], v[48:51], a[136:139], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v217 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[72:75], v[52:55], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v235, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[48:51], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v217 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[52:55], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[80:83], v[40:43], a[160:163], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v217 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[80:83], v[44:47], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[84:87], v[40:43], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v217 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[84:87], v[44:47], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[80:83], v[48:51], a[168:171], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v217 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[80:83], v[52:55], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[84:87], v[48:51], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v217 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[84:87], v[52:55], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s67                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v217 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[92:95], v[56:59], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[92:95], v[60:63], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[88:91], v[64:67], a[136:139], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[88:91], v[68:71], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[64:67], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[68:71], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s68                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[56:59], a[160:163], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[60:63], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[100:103], v[56:59], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[100:103], v[60:63], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[96:99], v[64:67], a[168:171], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[96:99], v[68:71], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[100:103], v[64:67], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[100:103], v[68:71], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[104:107], v[40:43], a[192:195], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[104:107], v[44:47], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[108:111], v[40:43], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[108:111], v[44:47], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[104:107], v[48:51], a[200:203], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[104:107], v[52:55], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[48:51], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[52:55], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[112:115], v[40:43], a[224:227], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[112:115], v[44:47], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[116:119], v[40:43], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[116:119], v[44:47], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[112:115], v[48:51], a[232:235], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[112:115], v[52:55], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[116:119], v[48:51], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[116:119], v[52:55], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[56:59], a[192:195], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[60:63], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[124:127], v[56:59], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[124:127], v[60:63], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[120:123], v[64:67], a[200:203], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[120:123], v[68:71], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[124:127], v[64:67], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[124:127], v[68:71], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[56:59], a[224:227], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[60:63], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[132:135], v[56:59], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[132:135], v[60:63], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[128:131], v[64:67], a[232:235], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[128:131], v[68:71], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[132:135], v[64:67], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[132:135], v[68:71], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[140:143], v[8:11], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v217 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[140:143], v[12:15], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v217 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[16:19], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v217 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[20:23], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[8:11], a[32:35], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v217 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[12:15], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[148:151], v[8:11], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v217 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[148:151], v[12:15], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[144:147], v[16:19], a[40:43], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v217 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[144:147], v[20:23], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v223, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[16:19], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v217 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[20:23], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[24:27], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v217 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[28:31], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v224, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[156:159], v[24:27], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[156:159], v[28:31], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[32:35], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[36:39], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v225, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[24:27], a[32:35], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[28:31], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v226, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[164:167], v[24:27], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[164:167], v[28:31], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[160:163], v[32:35], a[40:43], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[160:163], v[36:39], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[172:175], v[8:11], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[172:175], v[12:15], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[168:171], v[16:19], a[72:75], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[168:171], v[20:23], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[16:19], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[20:23], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[8:11], a[96:99], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[12:15], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[8:11], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[12:15], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[176:179], v[16:19], a[104:107], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[176:179], v[20:23], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[16:19], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[20:23], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[24:27], a[64:67], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[28:31], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[188:191], v[24:27], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[188:191], v[28:31], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[184:187], v[32:35], a[72:75], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[184:187], v[36:39], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[32:35], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[36:39], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[24:27], a[96:99], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[28:31], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[24:27], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[28:31], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[192:195], v[32:35], a[104:107], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[192:195], v[36:39], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[140:143], v[40:43], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v216                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[140:143], v[44:47], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[48:51], a[136:139], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[52:55], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v235, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[48:51], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[52:55], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[40:43], a[160:163], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[44:47], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[148:151], v[40:43], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[148:151], v[44:47], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[144:147], v[48:51], a[168:171], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[144:147], v[52:55], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[48:51], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[52:55], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[56:59], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v216 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[60:63], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[156:159], v[56:59], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[156:159], v[60:63], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[64:67], a[136:139], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[68:71], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[64:67], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[68:71], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s68                                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[56:59], a[160:163], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[60:63], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[164:167], v[56:59], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[164:167], v[60:63], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[160:163], v[64:67], a[168:171], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[160:163], v[68:71], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[168:171], v[40:43], a[192:195], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[168:171], v[44:47], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[172:175], v[40:43], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[172:175], v[44:47], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[168:171], v[48:51], a[200:203], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[168:171], v[52:55], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[48:51], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[52:55], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[40:43], a[224:227], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[44:47], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[40:43], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[44:47], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[176:179], v[48:51], a[232:235], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[176:179], v[52:55], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[48:51], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[52:55], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[184:187], v[56:59], a[192:195], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[184:187], v[60:63], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[188:191], v[56:59], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[188:191], v[60:63], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[184:187], v[64:67], a[200:203], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[184:187], v[68:71], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[188:191], v[64:67], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[188:191], v[68:71], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[192:195], v[56:59], a[224:227], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[192:195], v[60:63], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[56:59], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[60:63], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[192:195], v[64:67], a[232:235], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[192:195], v[68:71], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_branch label_03F0                                        
+	
+label_08F4:
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[76:79], v[8:11], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v220, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[76:79], v[12:15], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[72:75], v[16:19], a[8:11], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[72:75], v[20:23], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[16:19], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v221, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[20:23], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[8:11], a[32:35], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[12:15], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v216 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[84:87], v[8:11], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[84:87], v[12:15], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[80:83], v[16:19], a[40:43], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[80:83], v[20:23], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v216 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[16:19], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[20:23], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[92:95], v[24:27], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[92:95], v[28:31], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[88:91], v[32:35], a[8:11], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[88:91], v[36:39], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[32:35], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[36:39], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[24:27], a[32:35], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[28:31], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[100:103], v[24:27], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[100:103], v[28:31], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[96:99], v[32:35], a[40:43], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[96:99], v[36:39], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[8:11], a[64:67], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[12:15], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[108:111], v[8:11], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[108:111], v[12:15], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[104:107], v[16:19], a[72:75], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[104:107], v[20:23], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[16:19], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[20:23], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[8:11], a[96:99], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[12:15], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[116:119], v[8:11], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[116:119], v[12:15], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[112:115], v[16:19], a[104:107], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[112:115], v[20:23], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[16:19], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[20:23], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[124:127], v[24:27], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[124:127], v[28:31], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[120:123], v[32:35], a[72:75], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[120:123], v[36:39], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[32:35], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[36:39], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[24:27], a[96:99], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[28:31], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[132:135], v[24:27], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[132:135], v[28:31], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[128:131], v[32:35], a[104:107], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[128:131], v[36:39], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen    
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[40:43], a[128:131], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[44:47], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v217                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[76:79], v[40:43], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[76:79], v[44:47], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v217 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[72:75], v[48:51], a[136:139], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[72:75], v[52:55], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v217 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[48:51], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v235, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[52:55], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v217 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[80:83], v[40:43], a[160:163], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[80:83], v[44:47], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v217 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[84:87], v[40:43], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[84:87], v[44:47], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v217 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[80:83], v[48:51], a[168:171], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[80:83], v[52:55], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v217 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[84:87], v[48:51], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[84:87], v[52:55], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v217 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s67                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[92:95], v[56:59], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[92:95], v[60:63], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[88:91], v[64:67], a[136:139], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[88:91], v[68:71], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[64:67], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[68:71], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[56:59], a[160:163], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s68                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[60:63], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[100:103], v[56:59], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[100:103], v[60:63], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[96:99], v[64:67], a[168:171], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[96:99], v[68:71], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[100:103], v[64:67], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[100:103], v[68:71], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[104:107], v[40:43], a[192:195], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[104:107], v[44:47], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[108:111], v[40:43], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[108:111], v[44:47], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[104:107], v[48:51], a[200:203], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[104:107], v[52:55], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[48:51], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[52:55], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[112:115], v[40:43], a[224:227], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[112:115], v[44:47], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[116:119], v[40:43], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[116:119], v[44:47], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[112:115], v[48:51], a[232:235], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[112:115], v[52:55], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[116:119], v[48:51], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[116:119], v[52:55], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[56:59], a[192:195], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[60:63], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[124:127], v[56:59], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[124:127], v[60:63], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[120:123], v[64:67], a[200:203], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[120:123], v[68:71], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[124:127], v[64:67], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[124:127], v[68:71], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[56:59], a[224:227], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[60:63], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[132:135], v[56:59], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[132:135], v[60:63], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[128:131], v[64:67], a[232:235], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[128:131], v[68:71], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[132:135], v[64:67], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[132:135], v[68:71], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v217 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[140:143], v[8:11], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[140:143], v[12:15], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v217 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v217 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[16:19], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[20:23], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v217 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[8:11], a[32:35], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[12:15], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v217 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[148:151], v[8:11], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[148:151], v[12:15], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v217 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[144:147], v[16:19], a[40:43], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[144:147], v[20:23], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v217 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[16:19], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v223, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[20:23], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v217 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[24:27], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[28:31], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[156:159], v[24:27], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v224, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[156:159], v[28:31], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[32:35], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[36:39], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v225, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[24:27], a[32:35], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[28:31], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[164:167], v[24:27], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v226, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[164:167], v[28:31], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[160:163], v[32:35], a[40:43], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[160:163], v[36:39], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[172:175], v[8:11], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[172:175], v[12:15], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[168:171], v[16:19], a[72:75], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[168:171], v[20:23], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[16:19], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[20:23], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[8:11], a[96:99], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[12:15], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[8:11], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[12:15], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[176:179], v[16:19], a[104:107], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[176:179], v[20:23], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[16:19], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[20:23], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[24:27], a[64:67], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[28:31], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[188:191], v[24:27], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[188:191], v[28:31], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[184:187], v[32:35], a[72:75], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[184:187], v[36:39], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[32:35], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[36:39], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[24:27], a[96:99], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[28:31], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[24:27], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[28:31], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[192:195], v[32:35], a[104:107], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[192:195], v[36:39], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v233, s[16:19], 0 offen    
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v216                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[140:143], v[40:43], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[140:143], v[44:47], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[48:51], a[136:139], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[52:55], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[48:51], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v235, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[52:55], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[40:43], a[160:163], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[44:47], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[148:151], v[40:43], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[148:151], v[44:47], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[144:147], v[48:51], a[168:171], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[144:147], v[52:55], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[48:51], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[52:55], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v216 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[56:59], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[60:63], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[156:159], v[56:59], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[156:159], v[60:63], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[64:67], a[136:139], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[68:71], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[64:67], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[68:71], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[56:59], a[160:163], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s68                                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[60:63], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[164:167], v[56:59], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[164:167], v[60:63], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[160:163], v[64:67], a[168:171], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[160:163], v[68:71], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[168:171], v[40:43], a[192:195], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[168:171], v[44:47], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[172:175], v[40:43], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[172:175], v[44:47], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[168:171], v[48:51], a[200:203], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[168:171], v[52:55], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[48:51], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[52:55], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[40:43], a[224:227], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[44:47], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[40:43], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[44:47], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[176:179], v[48:51], a[232:235], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[176:179], v[52:55], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[48:51], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[52:55], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[184:187], v[56:59], a[192:195], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[184:187], v[60:63], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[188:191], v[56:59], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[188:191], v[60:63], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[184:187], v[64:67], a[200:203], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[184:187], v[68:71], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[188:191], v[64:67], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[188:191], v[68:71], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[192:195], v[56:59], a[224:227], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[192:195], v[60:63], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[56:59], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[60:63], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[192:195], v[64:67], a[232:235], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[192:195], v[68:71], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_branch label_08F4                                        
+	
+label_0DF7:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_barrier                                                  
+	s_cmp_eq_u32 s65, 0                                        
+	s_cbranch_scc1 label_1660                                  
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e64 v4, v4, 8                                
+	v_and_b32_e64 v5, v0, 15                                   
+	v_lshlrev_b32_e32 v5, 8, v5                                
+	v_add_i32 v4, v4, v5                                       
+	s_mul_i32 s62, s46, 0x4000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a0                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a3                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a16                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a17                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a18                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a19                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17]                                  
+	ds_write_b64 v4, v[18:19] offset:32                        
+	v_accvgpr_read_b32 v8, a32                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a33                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a34                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a48                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a49                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a50                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a51                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:64                        
+	ds_write_b64 v4, v[18:19] offset:96                        
+	v_accvgpr_read_b32 v8, a4                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a7                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a20                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a21                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a22                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a23                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4096                      
+	ds_write_b64 v4, v[18:19] offset:4128                      
+	v_accvgpr_read_b32 v8, a36                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a37                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a38                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a52                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a53                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a54                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a55                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4160                      
+	ds_write_b64 v4, v[18:19] offset:4192                      
+	v_accvgpr_read_b32 v8, a8                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a9                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a10                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a11                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8192                      
+	ds_write_b64 v4, v[18:19] offset:8224                      
+	v_accvgpr_read_b32 v8, a40                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a41                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a42                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a43                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8256                      
+	ds_write_b64 v4, v[18:19] offset:8288                      
+	v_accvgpr_read_b32 v8, a12                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a13                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a14                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a15                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12288                     
+	ds_write_b64 v4, v[18:19] offset:12320                     
+	v_accvgpr_read_b32 v8, a44                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a45                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a46                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a47                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12352                     
+	ds_write_b64 v4, v[18:19] offset:12384                     
+	v_accvgpr_read_b32 v8, a64                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a65                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a66                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a80                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a81                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a82                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a83                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:128                       
+	ds_write_b64 v4, v[18:19] offset:160                       
+	v_accvgpr_read_b32 v8, a96                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a97                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a98                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a112                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a113                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a114                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a115                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:192                       
+	ds_write_b64 v4, v[18:19] offset:224                       
+	v_accvgpr_read_b32 v8, a68                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a69                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a70                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a84                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a85                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a86                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a87                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4224                      
+	ds_write_b64 v4, v[18:19] offset:4256                      
+	v_accvgpr_read_b32 v8, a100                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a101                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a102                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a103                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a116                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a117                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a118                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a119                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4288                      
+	ds_write_b64 v4, v[18:19] offset:4320                      
+	v_accvgpr_read_b32 v8, a72                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a73                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a74                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a75                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8320                      
+	ds_write_b64 v4, v[18:19] offset:8352                      
+	v_accvgpr_read_b32 v8, a104                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a105                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a106                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a107                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a120                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a121                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a122                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a123                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8384                      
+	ds_write_b64 v4, v[18:19] offset:8416                      
+	v_accvgpr_read_b32 v8, a76                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a77                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a78                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a79                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12416                     
+	ds_write_b64 v4, v[18:19] offset:12448                     
+	v_accvgpr_read_b32 v8, a108                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a109                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a110                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a111                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a124                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a125                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a126                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a127                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12480                     
+	ds_write_b64 v4, v[18:19] offset:12512                     
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 4                                
+	v_add_i32 v4, v4, s62                                      
+	s_mul_i32 s63, s36, 0                                      
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4                                        
+	ds_read_b32 v17, v4 offset:256                             
+	ds_read_b32 v18, v4 offset:512                             
+	ds_read_b32 v19, v4 offset:768                             
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 4                                      
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:1024                            
+	ds_read_b32 v17, v4 offset:1280                            
+	ds_read_b32 v18, v4 offset:1536                            
+	ds_read_b32 v19, v4 offset:1792                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 8                                      
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:2048                            
+	ds_read_b32 v17, v4 offset:2304                            
+	ds_read_b32 v18, v4 offset:2560                            
+	ds_read_b32 v19, v4 offset:2816                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 12                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:3072                            
+	ds_read_b32 v17, v4 offset:3328                            
+	ds_read_b32 v18, v4 offset:3584                            
+	ds_read_b32 v19, v4 offset:3840                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 16                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:4096                            
+	ds_read_b32 v17, v4 offset:4352                            
+	ds_read_b32 v18, v4 offset:4608                            
+	ds_read_b32 v19, v4 offset:4864                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 20                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:5120                            
+	ds_read_b32 v17, v4 offset:5376                            
+	ds_read_b32 v18, v4 offset:5632                            
+	ds_read_b32 v19, v4 offset:5888                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 24                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:6144                            
+	ds_read_b32 v17, v4 offset:6400                            
+	ds_read_b32 v18, v4 offset:6656                            
+	ds_read_b32 v19, v4 offset:6912                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 28                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:7168                            
+	ds_read_b32 v17, v4 offset:7424                            
+	ds_read_b32 v18, v4 offset:7680                            
+	ds_read_b32 v19, v4 offset:7936                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 32                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:8192                            
+	ds_read_b32 v17, v4 offset:8448                            
+	ds_read_b32 v18, v4 offset:8704                            
+	ds_read_b32 v19, v4 offset:8960                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 36                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:9216                            
+	ds_read_b32 v17, v4 offset:9472                            
+	ds_read_b32 v18, v4 offset:9728                            
+	ds_read_b32 v19, v4 offset:9984                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 40                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:10240                           
+	ds_read_b32 v17, v4 offset:10496                           
+	ds_read_b32 v18, v4 offset:10752                           
+	ds_read_b32 v19, v4 offset:11008                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 44                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:11264                           
+	ds_read_b32 v17, v4 offset:11520                           
+	ds_read_b32 v18, v4 offset:11776                           
+	ds_read_b32 v19, v4 offset:12032                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 48                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:12288                           
+	ds_read_b32 v17, v4 offset:12544                           
+	ds_read_b32 v18, v4 offset:12800                           
+	ds_read_b32 v19, v4 offset:13056                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 52                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:13312                           
+	ds_read_b32 v17, v4 offset:13568                           
+	ds_read_b32 v18, v4 offset:13824                           
+	ds_read_b32 v19, v4 offset:14080                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 56                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:14336                           
+	ds_read_b32 v17, v4 offset:14592                           
+	ds_read_b32 v18, v4 offset:14848                           
+	ds_read_b32 v19, v4 offset:15104                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 60                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:15360                           
+	ds_read_b32 v17, v4 offset:15616                           
+	ds_read_b32 v18, v4 offset:15872                           
+	ds_read_b32 v19, v4 offset:16128                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e64 v4, v4, 8                                
+	v_and_b32_e64 v5, v0, 15                                   
+	v_lshlrev_b32_e32 v5, 8, v5                                
+	v_add_i32 v4, v4, v5                                       
+	s_mul_i32 s62, s46, 0x4000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a128                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a129                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a130                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a131                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a144                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a145                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a146                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a147                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17]                                  
+	ds_write_b64 v4, v[18:19] offset:32                        
+	v_accvgpr_read_b32 v8, a160                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a161                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a162                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a163                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a176                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a177                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a178                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a179                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:64                        
+	ds_write_b64 v4, v[18:19] offset:96                        
+	v_accvgpr_read_b32 v8, a132                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a133                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a134                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a135                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a148                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a149                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a150                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a151                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4096                      
+	ds_write_b64 v4, v[18:19] offset:4128                      
+	v_accvgpr_read_b32 v8, a164                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a165                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a166                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a167                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a180                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a181                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a182                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a183                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4160                      
+	ds_write_b64 v4, v[18:19] offset:4192                      
+	v_accvgpr_read_b32 v8, a136                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a137                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a138                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a139                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a152                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a153                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a154                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a155                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8192                      
+	ds_write_b64 v4, v[18:19] offset:8224                      
+	v_accvgpr_read_b32 v8, a168                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a169                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a170                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a171                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a184                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a185                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a186                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a187                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8256                      
+	ds_write_b64 v4, v[18:19] offset:8288                      
+	v_accvgpr_read_b32 v8, a140                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a141                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a142                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a143                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a156                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a157                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a158                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a159                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12288                     
+	ds_write_b64 v4, v[18:19] offset:12320                     
+	v_accvgpr_read_b32 v8, a172                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a173                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a174                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a175                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a188                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a189                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a190                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a191                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12352                     
+	ds_write_b64 v4, v[18:19] offset:12384                     
+	v_accvgpr_read_b32 v8, a192                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a193                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a194                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a195                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a208                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a209                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a210                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a211                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:128                       
+	ds_write_b64 v4, v[18:19] offset:160                       
+	v_accvgpr_read_b32 v8, a224                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a225                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a226                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a227                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a240                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a241                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a242                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a243                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:192                       
+	ds_write_b64 v4, v[18:19] offset:224                       
+	v_accvgpr_read_b32 v8, a196                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a197                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a198                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a199                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a212                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a213                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a214                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a215                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4224                      
+	ds_write_b64 v4, v[18:19] offset:4256                      
+	v_accvgpr_read_b32 v8, a228                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a229                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a230                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a231                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a244                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a245                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a246                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a247                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4288                      
+	ds_write_b64 v4, v[18:19] offset:4320                      
+	v_accvgpr_read_b32 v8, a200                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a201                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a202                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a203                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a216                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a217                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a218                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a219                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8320                      
+	ds_write_b64 v4, v[18:19] offset:8352                      
+	v_accvgpr_read_b32 v8, a232                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a233                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a234                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a235                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a248                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a249                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a250                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a251                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8384                      
+	ds_write_b64 v4, v[18:19] offset:8416                      
+	v_accvgpr_read_b32 v8, a204                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a205                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a206                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a207                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a220                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a221                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a222                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a223                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12416                     
+	ds_write_b64 v4, v[18:19] offset:12448                     
+	v_accvgpr_read_b32 v8, a236                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a237                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a238                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a239                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a252                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a253                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a254                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a255                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12480                     
+	ds_write_b64 v4, v[18:19] offset:12512                     
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 4                                
+	v_add_i32 v4, v4, s62                                      
+	s_mul_i32 s63, s36, 0                                      
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4                                        
+	ds_read_b32 v17, v4 offset:256                             
+	ds_read_b32 v18, v4 offset:512                             
+	ds_read_b32 v19, v4 offset:768                             
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 4                                      
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:1024                            
+	ds_read_b32 v17, v4 offset:1280                            
+	ds_read_b32 v18, v4 offset:1536                            
+	ds_read_b32 v19, v4 offset:1792                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 8                                      
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:2048                            
+	ds_read_b32 v17, v4 offset:2304                            
+	ds_read_b32 v18, v4 offset:2560                            
+	ds_read_b32 v19, v4 offset:2816                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 12                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:3072                            
+	ds_read_b32 v17, v4 offset:3328                            
+	ds_read_b32 v18, v4 offset:3584                            
+	ds_read_b32 v19, v4 offset:3840                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 16                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:4096                            
+	ds_read_b32 v17, v4 offset:4352                            
+	ds_read_b32 v18, v4 offset:4608                            
+	ds_read_b32 v19, v4 offset:4864                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 20                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:5120                            
+	ds_read_b32 v17, v4 offset:5376                            
+	ds_read_b32 v18, v4 offset:5632                            
+	ds_read_b32 v19, v4 offset:5888                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 24                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:6144                            
+	ds_read_b32 v17, v4 offset:6400                            
+	ds_read_b32 v18, v4 offset:6656                            
+	ds_read_b32 v19, v4 offset:6912                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 28                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:7168                            
+	ds_read_b32 v17, v4 offset:7424                            
+	ds_read_b32 v18, v4 offset:7680                            
+	ds_read_b32 v19, v4 offset:7936                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 32                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:8192                            
+	ds_read_b32 v17, v4 offset:8448                            
+	ds_read_b32 v18, v4 offset:8704                            
+	ds_read_b32 v19, v4 offset:8960                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 36                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:9216                            
+	ds_read_b32 v17, v4 offset:9472                            
+	ds_read_b32 v18, v4 offset:9728                            
+	ds_read_b32 v19, v4 offset:9984                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 40                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:10240                           
+	ds_read_b32 v17, v4 offset:10496                           
+	ds_read_b32 v18, v4 offset:10752                           
+	ds_read_b32 v19, v4 offset:11008                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 44                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:11264                           
+	ds_read_b32 v17, v4 offset:11520                           
+	ds_read_b32 v18, v4 offset:11776                           
+	ds_read_b32 v19, v4 offset:12032                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 48                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:12288                           
+	ds_read_b32 v17, v4 offset:12544                           
+	ds_read_b32 v18, v4 offset:12800                           
+	ds_read_b32 v19, v4 offset:13056                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 52                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:13312                           
+	ds_read_b32 v17, v4 offset:13568                           
+	ds_read_b32 v18, v4 offset:13824                           
+	ds_read_b32 v19, v4 offset:14080                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 56                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:14336                           
+	ds_read_b32 v17, v4 offset:14592                           
+	ds_read_b32 v18, v4 offset:14848                           
+	ds_read_b32 v19, v4 offset:15104                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 60                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:15360                           
+	ds_read_b32 v17, v4 offset:15616                           
+	ds_read_b32 v18, v4 offset:15872                           
+	ds_read_b32 v19, v4 offset:16128                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_branch label_1BA0                                        
+	
+label_1660:
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a0                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a3                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a16                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a17                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a18                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a19                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a32                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a33                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a34                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a48                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a49                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a50                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a51                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a7                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a20                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a21                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a22                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a23                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a36                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a37                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a38                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a52                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a53                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a54                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a55                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a8                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a9                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a10                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a11                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a40                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a41                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a42                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a43                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a12                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a13                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a14                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a15                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a44                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a45                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a46                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a47                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a65                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a66                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a80                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a81                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a82                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a83                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a96                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a97                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a98                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a112                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a113                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a114                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a115                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a69                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a70                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a84                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a85                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a86                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a87                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a100                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a101                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a102                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a103                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a116                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a117                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a118                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a119                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a72                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a73                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a74                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a75                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a104                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a105                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a106                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a107                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a120                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a121                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a122                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a123                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a76                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a77                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a78                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a79                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a108                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a109                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a110                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a111                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a124                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a125                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a126                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a127                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a129                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a130                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a131                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a144                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a145                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a146                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a147                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a160                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a161                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a162                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a163                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a176                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a177                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a178                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a179                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a133                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a134                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a135                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a148                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a149                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a150                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a151                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a164                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a165                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a166                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a167                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a180                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a181                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a182                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a183                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a136                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a137                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a138                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a139                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a152                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a153                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a154                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a155                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a168                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a169                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a170                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a171                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a184                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a185                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a186                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a187                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a140                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a141                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a142                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a143                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a156                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a157                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a158                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a159                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a172                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a173                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a174                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a175                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a188                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a189                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a190                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a191                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a193                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a194                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a195                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a208                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a209                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a210                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a211                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a224                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a225                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a226                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a227                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a240                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a241                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a242                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a243                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a197                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a198                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a199                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a212                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a213                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a214                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a215                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a228                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a229                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a230                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a231                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a244                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a245                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a246                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a247                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a200                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a201                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a202                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a203                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a216                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a217                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a218                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a219                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a232                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a233                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a234                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a235                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a248                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a249                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a250                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a251                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a204                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a205                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a206                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a207                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a220                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a221                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a222                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a223                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a236                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a237                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a238                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a239                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a252                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a253                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a254                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a255                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	
+label_1BA0:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB.s
@@ -1,0 +1,4151 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	s_mov_b32 s64, s4                                          
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	s_load_dword s65, s[0:1], 0x170                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_mov_b32 s6, -16                                          
+	s_mov_b32 s10, -16                                         
+	s_mov_b32 s18, -16                                         
+	s_mov_b32 s14, -16                                         
+	s_mov_b32 s22, -16                                         
+	s_mov_b32 s26, -16                                         
+	s_mov_b32 s7, 0x20000                                      
+	s_mov_b32 s11, 0x20000                                     
+	s_mov_b32 s19, 0x20000                                     
+	s_mov_b32 s15, 0x20000                                     
+	s_mov_b32 s23, 0x20000                                     
+	s_mov_b32 s27, 0x20000                                     
+	s_and_b32 s5, s5, 0xffff                                   
+	s_and_b32 s9, s9, 0xffff                                   
+	s_and_b32 s17, s17, 0xffff                                 
+	s_and_b32 s13, s13, 0xffff                                 
+	s_and_b32 s21, s21, 0xffff                                 
+	s_and_b32 s25, s25, 0xffff                                 
+	s_or_b32 s5, s5, 0x40000                                   
+	s_or_b32 s9, s9, 0x40000                                   
+	s_or_b32 s17, s17, 0x40000                                 
+	s_or_b32 s13, s13, 0x40000                                 
+	s_or_b32 s21, s21, 0x40000                                 
+	s_or_b32 s25, s25, 0x40000                                 
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_0068                                  
+	s_lshr_b32 s66, s45, s65                                   
+	s_add_u32 s66, s66, 0xff                                   
+	s_lshr_b32 s66, s66, 8                                     
+	s_lshl_b32 s66, s66, 8                                     
+	s_mul_i32 s63, s66, s64                                    
+	s_sub_i32 s62, s45, s63                                    
+	s_cmp_lt_i32 s62, s66                                      
+	s_cselect_b32 s45, s62, s66                                
+	
+label_0068:
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s63, s37, s62                                    
+	s_mov_b32 s14, s63                                         
+	s_mov_b32 s15, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_0080                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_lshr_b32 s62, s63, 1                                     
+	s_add_u32 s12, s12, s62                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_u32 s14, s14, s62                                    
+	
+label_0080:
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	s_mul_i32 s67, 0x420, s46                                  
+	s_add_u32 s67, 0x800, s67                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v216, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v216, v5, v216                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v216, v6, v216                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v216, v4, v216                               
+	s_mov_b32 s62, 0x800                                       
+	v_add_u32_e64 v216, v216, s62                              
+	v_add_u32_e32 v217, 0x4200, v216                           
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s63, s39, s62                                    
+	s_mov_b32 s22, s63                                         
+	s_mov_b32 s23, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_00D0                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_sub_u32 s22, s22, s63                                    
+	
+label_00D0:
+	v_lshlrev_b32_e32 v218, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v218, s63, v218                              
+	s_mul_i32 s68, s46, 0x100                                  
+	s_add_i32 s68, s68, 0                                      
+	v_lshlrev_b32_e32 v219, 2, v0                              
+	v_add_u32_e32 v219, 0, v219                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s63, s38, s62                                    
+	s_mov_b32 s18, s63                                         
+	s_mov_b32 s19, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_00F2                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_lshr_b32 s62, s63, 1                                     
+	s_mul_i32 s62, s62, 16                                     
+	s_add_u32 s16, s16, s62                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_u32 s18, s18, s62                                    
+	
+label_00F2:
+	v_lshlrev_b32_e32 v220, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v220, s62, v220                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, 0x400, v220                            
+	v_add_u32_e32 v225, 0x400, v221                            
+	v_add_u32_e32 v226, 0x400, v222                            
+	v_add_u32_e32 v227, 0x400, v223                            
+	s_mul_i32 s62, 64, s38                                     
+	v_add_u32_e32 v228, s62, v220                              
+	v_add_u32_e32 v229, s62, v221                              
+	v_add_u32_e32 v230, s62, v222                              
+	v_add_u32_e32 v231, s62, v223                              
+	v_add_u32_e32 v232, s62, v224                              
+	v_add_u32_e32 v233, s62, v225                              
+	v_add_u32_e32 v234, s62, v226                              
+	v_add_u32_e32 v235, s62, v227                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s63, s40, s62                                    
+	s_mov_b32 s26, s63                                         
+	s_mov_b32 s27, 0x20000                                     
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_0122                                  
+	s_mul_i32 s63, s66, s64                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_u32 s26, s26, s63                                    
+	
+label_0122:
+	v_lshlrev_b32_e32 v236, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v236, s63, v236                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	s_mov_b32 s69, 0x80                                        
+	s_mov_b32 s70, 0x800                                       
+	s_mov_b32 s71, 0x100                                       
+	s_mov_b32 s72, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s67                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x1080, s67                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0, s68                                       
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s67                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0x3180, s67                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	s_add_u32 s12, s12, s69                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s69                                    
+	s_add_u32 s20, s20, s71                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s71                                    
+	buffer_load_dwordx4 v[72:75], v220, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[76:79], v221, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	buffer_load_dwordx4 v[80:83], v222, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	buffer_load_dwordx4 v[84:87], v223, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[88:91], v224, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[92:95], v225, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[96:99], v226, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[100:103], v227, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dword v204, v236, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dword v205, v237, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[104:107], v228, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[108:111], v229, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dwordx4 v[112:115], v230, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dwordx4 v[116:119], v231, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	buffer_load_dwordx4 v[120:123], v232, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	buffer_load_dwordx4 v[124:127], v233, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	buffer_load_dwordx4 v[128:131], v234, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	buffer_load_dwordx4 v[132:135], v235, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	buffer_load_dword v206, v238, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	buffer_load_dword v207, v239, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s70, s70, 0                                  
+	s_cselect_b32 s72, s72, 0                                  
+	s_add_u32 s16, s16, s70                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s70                                    
+	s_add_u32 s24, s24, s72                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s72                                    
+	s_add_u32 m0, 0x4200, s67                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	s_add_u32 m0, 0x5280, s67                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	s_add_u32 m0, 0x400, s68                                   
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	s_add_u32 m0, 0x6300, s67                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	s_add_u32 m0, 0x7380, s67                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	v_accvgpr_write_b32 a240, 0                                
+	v_accvgpr_write_b32 a241, 0                                
+	v_accvgpr_write_b32 a242, 0                                
+	v_accvgpr_write_b32 a243, 0                                
+	v_accvgpr_write_b32 a244, 0                                
+	v_accvgpr_write_b32 a245, 0                                
+	v_accvgpr_write_b32 a246, 0                                
+	v_accvgpr_write_b32 a247, 0                                
+	v_accvgpr_write_b32 a248, 0                                
+	v_accvgpr_write_b32 a249, 0                                
+	v_accvgpr_write_b32 a250, 0                                
+	v_accvgpr_write_b32 a251, 0                                
+	v_accvgpr_write_b32 a252, 0                                
+	v_accvgpr_write_b32 a253, 0                                
+	v_accvgpr_write_b32 a254, 0                                
+	v_accvgpr_write_b32 a255, 0                                
+	s_waitcnt vmcnt(27)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v216                                 
+	ds_read_b128 v[24:27], v216 offset:64                      
+	ds_read_b128 v[12:15], v216 offset:512                     
+	ds_read_b128 v[28:31], v216 offset:576                     
+	ds_read_b128 v[16:19], v216 offset:4224                    
+	ds_read_b128 v[32:35], v216 offset:4288                    
+	ds_read_b128 v[20:23], v216 offset:4736                    
+	ds_read_b128 v[36:39], v216 offset:4800                    
+	ds_read_b32 v200, v219                                     
+	ds_read_b32 v201, v219 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x80                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x80                                     
+	s_cselect_b32 s62, s62, 0x80                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s62, s62, s63                                    
+	s_mov_b32 s6, s62                                          
+	s_mov_b32 s7, 0x20000                                      
+	s_cmp_gt_i32 s65, 0                                        
+	s_cbranch_scc0 label_03D8                                  
+	v_mul_i32_i24_e64 v4, v0, 4                                
+	s_mul_i32 s62, s46, 0x100                                  
+	v_add_u32_e32 v240, s62, v4                                
+	v_add_u32_e32 v241, 0x80, v240                             
+	s_mul_i32 s62, s36, 64                                     
+	v_add_u32_e32 v242, s62, v240                              
+	v_add_u32_e32 v243, s62, v241                              
+	s_branch label_03EE                                        
+	
+label_03D8:
+	v_and_b32_e64 v4, v0, 15                                   
+	v_mul_lo_u32 v240, s36, v4                                 
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e64 v4, v4, 16                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e64 v5, v5, 1                                    
+	v_mul_i32_i24_e64 v5, v5, 32                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_add_u32_e32 v240, v4, v240                               
+	s_mul_i32 s62, s46, 0x100                                  
+	v_add_u32_e32 v240, s62, v240                              
+	v_add_u32_e32 v241, 0x80, v240                             
+	s_mul_i32 s62, s36, 64                                     
+	v_add_u32_e32 v242, s62, v240                              
+	v_add_u32_e32 v243, s62, v241                              
+	
+label_03EE:
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_08F4                                  
+	
+label_03F0:
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v220, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[76:79], v[8:11], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[76:79], v[12:15], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[72:75], v[16:19], a[8:11], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[72:75], v[20:23], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v221, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[16:19], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[20:23], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[8:11], a[32:35], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[12:15], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[84:87], v[8:11], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v216 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[84:87], v[12:15], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[80:83], v[16:19], a[40:43], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[80:83], v[20:23], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[16:19], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v216 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[20:23], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[92:95], v[24:27], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[92:95], v[28:31], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[88:91], v[32:35], a[8:11], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[88:91], v[36:39], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[32:35], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[36:39], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[24:27], a[32:35], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[28:31], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[100:103], v[24:27], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[100:103], v[28:31], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[96:99], v[32:35], a[40:43], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[96:99], v[36:39], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[8:11], a[64:67], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[12:15], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[108:111], v[8:11], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[108:111], v[12:15], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[104:107], v[16:19], a[72:75], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[104:107], v[20:23], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[16:19], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[20:23], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[8:11], a[96:99], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[12:15], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[116:119], v[8:11], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[116:119], v[12:15], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[112:115], v[16:19], a[104:107], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[112:115], v[20:23], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[16:19], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[20:23], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[124:127], v[24:27], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[124:127], v[28:31], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[120:123], v[32:35], a[72:75], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[120:123], v[36:39], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[32:35], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[36:39], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[24:27], a[96:99], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[28:31], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[132:135], v[24:27], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[132:135], v[28:31], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[128:131], v[32:35], a[104:107], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[128:131], v[36:39], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[40:43], a[128:131], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[44:47], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[76:79], v[40:43], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v217                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[76:79], v[44:47], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[72:75], v[48:51], a[136:139], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v217 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[72:75], v[52:55], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v235, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[48:51], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v217 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[52:55], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[80:83], v[40:43], a[160:163], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v217 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[80:83], v[44:47], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[84:87], v[40:43], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v217 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[84:87], v[44:47], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[80:83], v[48:51], a[168:171], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v217 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[80:83], v[52:55], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[84:87], v[48:51], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v217 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[84:87], v[52:55], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s67                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v217 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[92:95], v[56:59], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[92:95], v[60:63], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[88:91], v[64:67], a[136:139], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[88:91], v[68:71], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[64:67], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[68:71], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s68                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[56:59], a[160:163], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[60:63], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[100:103], v[56:59], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[100:103], v[60:63], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[96:99], v[64:67], a[168:171], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[96:99], v[68:71], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[100:103], v[64:67], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[100:103], v[68:71], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[104:107], v[40:43], a[192:195], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[104:107], v[44:47], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[108:111], v[40:43], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[108:111], v[44:47], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[104:107], v[48:51], a[200:203], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[104:107], v[52:55], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[48:51], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[52:55], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[112:115], v[40:43], a[224:227], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[112:115], v[44:47], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[116:119], v[40:43], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[116:119], v[44:47], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[112:115], v[48:51], a[232:235], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[112:115], v[52:55], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[116:119], v[48:51], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[116:119], v[52:55], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[56:59], a[192:195], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[60:63], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[124:127], v[56:59], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[124:127], v[60:63], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[120:123], v[64:67], a[200:203], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[120:123], v[68:71], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[124:127], v[64:67], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[124:127], v[68:71], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[56:59], a[224:227], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[60:63], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[132:135], v[56:59], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[132:135], v[60:63], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[128:131], v[64:67], a[232:235], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[128:131], v[68:71], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[132:135], v[64:67], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[132:135], v[68:71], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[140:143], v[8:11], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v217 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[140:143], v[12:15], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v217 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[16:19], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v217 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[20:23], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[8:11], a[32:35], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v217 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[12:15], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[148:151], v[8:11], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v217 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[148:151], v[12:15], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[144:147], v[16:19], a[40:43], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v217 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[144:147], v[20:23], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v223, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[16:19], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v217 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[20:23], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[24:27], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v217 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[28:31], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v224, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[156:159], v[24:27], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[156:159], v[28:31], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[32:35], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[36:39], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v225, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[24:27], a[32:35], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[28:31], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v226, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[164:167], v[24:27], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[164:167], v[28:31], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[160:163], v[32:35], a[40:43], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[160:163], v[36:39], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[172:175], v[8:11], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[172:175], v[12:15], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[168:171], v[16:19], a[72:75], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[168:171], v[20:23], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[16:19], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[20:23], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[8:11], a[96:99], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[12:15], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[8:11], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[12:15], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[176:179], v[16:19], a[104:107], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[176:179], v[20:23], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[16:19], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[20:23], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[24:27], a[64:67], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[28:31], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[188:191], v[24:27], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[188:191], v[28:31], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[184:187], v[32:35], a[72:75], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[184:187], v[36:39], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[32:35], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[36:39], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[24:27], a[96:99], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[28:31], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[24:27], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[28:31], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[192:195], v[32:35], a[104:107], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[192:195], v[36:39], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[140:143], v[40:43], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v216                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[140:143], v[44:47], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[48:51], a[136:139], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[52:55], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v235, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[48:51], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[52:55], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[40:43], a[160:163], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[44:47], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[148:151], v[40:43], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[148:151], v[44:47], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[144:147], v[48:51], a[168:171], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[144:147], v[52:55], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[48:51], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[52:55], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[56:59], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v216 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[60:63], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[156:159], v[56:59], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[156:159], v[60:63], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[64:67], a[136:139], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[68:71], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[64:67], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[68:71], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s68                                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[56:59], a[160:163], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[60:63], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[164:167], v[56:59], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[164:167], v[60:63], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[160:163], v[64:67], a[168:171], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[160:163], v[68:71], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[168:171], v[40:43], a[192:195], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[168:171], v[44:47], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[172:175], v[40:43], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[172:175], v[44:47], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[168:171], v[48:51], a[200:203], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[168:171], v[52:55], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[48:51], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[52:55], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[40:43], a[224:227], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[44:47], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[40:43], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[44:47], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[176:179], v[48:51], a[232:235], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[176:179], v[52:55], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[48:51], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[52:55], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[184:187], v[56:59], a[192:195], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[184:187], v[60:63], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[188:191], v[56:59], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[188:191], v[60:63], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[184:187], v[64:67], a[200:203], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[184:187], v[68:71], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[188:191], v[64:67], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[188:191], v[68:71], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[192:195], v[56:59], a[224:227], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[192:195], v[60:63], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[56:59], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[60:63], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[192:195], v[64:67], a[232:235], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[192:195], v[68:71], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_branch label_03F0                                        
+	
+label_08F4:
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[76:79], v[8:11], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v220, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[76:79], v[12:15], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[72:75], v[16:19], a[8:11], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[72:75], v[20:23], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[16:19], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v221, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[20:23], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[8:11], a[32:35], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[12:15], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v216 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[84:87], v[8:11], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[84:87], v[12:15], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[80:83], v[16:19], a[40:43], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[80:83], v[20:23], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v216 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[16:19], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[20:23], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[92:95], v[24:27], a[16:19], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[92:95], v[28:31], a[20:23], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[88:91], v[32:35], a[8:11], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[88:91], v[36:39], a[12:15], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[32:35], a[24:27], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[36:39], a[28:31], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[24:27], a[32:35], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[28:31], a[36:39], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[100:103], v[24:27], a[48:51], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[100:103], v[28:31], a[52:55], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[96:99], v[32:35], a[40:43], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[96:99], v[36:39], a[44:47], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[8:11], a[64:67], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[12:15], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[108:111], v[8:11], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[108:111], v[12:15], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[104:107], v[16:19], a[72:75], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[104:107], v[20:23], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[16:19], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[20:23], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[8:11], a[96:99], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[12:15], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[116:119], v[8:11], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[116:119], v[12:15], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[112:115], v[16:19], a[104:107], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[112:115], v[20:23], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[16:19], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[20:23], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[124:127], v[24:27], a[80:83], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[124:127], v[28:31], a[84:87], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[120:123], v[32:35], a[72:75], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[120:123], v[36:39], a[76:79], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[32:35], a[88:91], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[36:39], a[92:95], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[24:27], a[96:99], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[28:31], a[100:103], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[132:135], v[24:27], a[112:115], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[132:135], v[28:31], a[116:119], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[128:131], v[32:35], a[104:107], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[128:131], v[36:39], a[108:111], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen nt    
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[40:43], a[128:131], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[44:47], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v217                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[76:79], v[40:43], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[76:79], v[44:47], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v217 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[72:75], v[48:51], a[136:139], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[72:75], v[52:55], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v217 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[76:79], v[48:51], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v235, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[76:79], v[52:55], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v217 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[80:83], v[40:43], a[160:163], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[80:83], v[44:47], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v217 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[84:87], v[40:43], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[84:87], v[44:47], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v217 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[80:83], v[48:51], a[168:171], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[80:83], v[52:55], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v217 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[84:87], v[48:51], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[84:87], v[52:55], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v217 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s67                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[92:95], v[56:59], a[144:147], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[92:95], v[60:63], a[148:151], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[88:91], v[64:67], a[136:139], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[88:91], v[68:71], a[140:143], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[64:67], a[152:155], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[68:71], a[156:159], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[96:99], v[56:59], a[160:163], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s68                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[96:99], v[60:63], a[164:167], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[100:103], v[56:59], a[176:179], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[100:103], v[60:63], a[180:183], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[96:99], v[64:67], a[168:171], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[96:99], v[68:71], a[172:175], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[100:103], v[64:67], a[184:187], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[100:103], v[68:71], a[188:191], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[104:107], v[40:43], a[192:195], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[104:107], v[44:47], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[108:111], v[40:43], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[108:111], v[44:47], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[104:107], v[48:51], a[200:203], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[104:107], v[52:55], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[48:51], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[52:55], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[112:115], v[40:43], a[224:227], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[112:115], v[44:47], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[116:119], v[40:43], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[116:119], v[44:47], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[112:115], v[48:51], a[232:235], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[112:115], v[52:55], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[116:119], v[48:51], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[116:119], v[52:55], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[56:59], a[192:195], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[60:63], a[196:199], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[124:127], v[56:59], a[208:211], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[124:127], v[60:63], a[212:215], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[120:123], v[64:67], a[200:203], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[120:123], v[68:71], a[204:207], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[124:127], v[64:67], a[216:219], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[124:127], v[68:71], a[220:223], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[56:59], a[224:227], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[60:63], a[228:231], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[132:135], v[56:59], a[240:243], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[132:135], v[60:63], a[244:247], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[128:131], v[64:67], a[232:235], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[128:131], v[68:71], a[236:239], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[132:135], v[64:67], a[248:251], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[132:135], v[68:71], a[252:255], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v217 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[140:143], v[8:11], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[72:75], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[140:143], v[12:15], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v217 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v217 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[16:19], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[76:79], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[20:23], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v217 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[8:11], a[32:35], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[12:15], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v217 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[148:151], v[8:11], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[80:83], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[148:151], v[12:15], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v217 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[144:147], v[16:19], a[40:43], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[144:147], v[20:23], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v217 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[16:19], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v223, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[20:23], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v217 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[24:27], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[28:31], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v219 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[156:159], v[24:27], a[16:19], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v224, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[156:159], v[28:31], a[20:23], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v219 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[32:35], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[36:39], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v225, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[24:27], a[32:35], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[28:31], a[36:39], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[164:167], v[24:27], a[48:51], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v226, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[164:167], v[28:31], a[52:55], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[160:163], v[32:35], a[40:43], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[160:163], v[36:39], a[44:47], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[172:175], v[8:11], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[172:175], v[12:15], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[168:171], v[16:19], a[72:75], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[168:171], v[20:23], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[16:19], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[20:23], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[8:11], a[96:99], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[12:15], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[8:11], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[12:15], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[176:179], v[16:19], a[104:107], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[176:179], v[20:23], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[16:19], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[20:23], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[24:27], a[64:67], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[28:31], a[68:71], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[188:191], v[24:27], a[80:83], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[188:191], v[28:31], a[84:87], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[184:187], v[32:35], a[72:75], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[184:187], v[36:39], a[76:79], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[32:35], a[88:91], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[36:39], a[92:95], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[24:27], a[96:99], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[28:31], a[100:103], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[24:27], a[112:115], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[28:31], a[116:119], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[192:195], v[32:35], a[104:107], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[192:195], v[36:39], a[108:111], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v233, s[16:19], 0 offen nt    
+	s_waitcnt vmcnt(18) lgkmcnt(0)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v216                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[140:143], v[40:43], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[140:143], v[44:47], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[48:51], a[136:139], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[52:55], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[48:51], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v235, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[52:55], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[40:43], a[160:163], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[44:47], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[148:151], v[40:43], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[148:151], v[44:47], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[144:147], v[48:51], a[168:171], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[144:147], v[52:55], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[48:51], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[52:55], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v216 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[56:59], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[60:63], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v219                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[156:159], v[56:59], a[144:147], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[156:159], v[60:63], a[148:151], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v219 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[64:67], a[136:139], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[68:71], a[140:143], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[64:67], a[152:155], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[68:71], a[156:159], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[56:59], a[160:163], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s68                                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[60:63], a[164:167], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[164:167], v[56:59], a[176:179], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v218, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[164:167], v[60:63], a[180:183], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[160:163], v[64:67], a[168:171], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[160:163], v[68:71], a[172:175], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[168:171], v[40:43], a[192:195], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[168:171], v[44:47], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[172:175], v[40:43], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[172:175], v[44:47], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[168:171], v[48:51], a[200:203], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s67                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[168:171], v[52:55], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[48:51], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[52:55], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[40:43], a[224:227], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[44:47], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[40:43], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[44:47], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[176:179], v[48:51], a[232:235], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[176:179], v[52:55], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[48:51], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s72, s72, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[52:55], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[184:187], v[56:59], a[192:195], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[184:187], v[60:63], a[196:199], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[188:191], v[56:59], a[208:211], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[188:191], v[60:63], a[212:215], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[184:187], v[64:67], a[200:203], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[184:187], v[68:71], a[204:207], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[188:191], v[64:67], a[216:219], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[188:191], v[68:71], a[220:223], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[192:195], v[56:59], a[224:227], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[192:195], v[60:63], a[228:231], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[56:59], a[240:243], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s72                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[60:63], a[244:247], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[192:195], v[64:67], a[232:235], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[192:195], v[68:71], a[236:239], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0DF7                                  
+	s_branch label_08F4                                        
+	
+label_0DF7:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_barrier                                                  
+	s_cmp_eq_u32 s65, 0                                        
+	s_cbranch_scc1 label_1660                                  
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e64 v4, v4, 8                                
+	v_and_b32_e64 v5, v0, 15                                   
+	v_lshlrev_b32_e32 v5, 8, v5                                
+	v_add_i32 v4, v4, v5                                       
+	s_mul_i32 s62, s46, 0x4000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a0                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a3                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a16                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a17                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a18                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a19                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17]                                  
+	ds_write_b64 v4, v[18:19] offset:32                        
+	v_accvgpr_read_b32 v8, a32                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a33                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a34                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a48                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a49                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a50                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a51                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:64                        
+	ds_write_b64 v4, v[18:19] offset:96                        
+	v_accvgpr_read_b32 v8, a4                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a7                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a20                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a21                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a22                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a23                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4096                      
+	ds_write_b64 v4, v[18:19] offset:4128                      
+	v_accvgpr_read_b32 v8, a36                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a37                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a38                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a52                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a53                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a54                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a55                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4160                      
+	ds_write_b64 v4, v[18:19] offset:4192                      
+	v_accvgpr_read_b32 v8, a8                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a9                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a10                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a11                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8192                      
+	ds_write_b64 v4, v[18:19] offset:8224                      
+	v_accvgpr_read_b32 v8, a40                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a41                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a42                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a43                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8256                      
+	ds_write_b64 v4, v[18:19] offset:8288                      
+	v_accvgpr_read_b32 v8, a12                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a13                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a14                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a15                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12288                     
+	ds_write_b64 v4, v[18:19] offset:12320                     
+	v_accvgpr_read_b32 v8, a44                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a45                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a46                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a47                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12352                     
+	ds_write_b64 v4, v[18:19] offset:12384                     
+	v_accvgpr_read_b32 v8, a64                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a65                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a66                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a80                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a81                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a82                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a83                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:128                       
+	ds_write_b64 v4, v[18:19] offset:160                       
+	v_accvgpr_read_b32 v8, a96                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a97                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a98                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a112                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a113                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a114                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a115                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:192                       
+	ds_write_b64 v4, v[18:19] offset:224                       
+	v_accvgpr_read_b32 v8, a68                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a69                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a70                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a84                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a85                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a86                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a87                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4224                      
+	ds_write_b64 v4, v[18:19] offset:4256                      
+	v_accvgpr_read_b32 v8, a100                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a101                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a102                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a103                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a116                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a117                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a118                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a119                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4288                      
+	ds_write_b64 v4, v[18:19] offset:4320                      
+	v_accvgpr_read_b32 v8, a72                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a73                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a74                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a75                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8320                      
+	ds_write_b64 v4, v[18:19] offset:8352                      
+	v_accvgpr_read_b32 v8, a104                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a105                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a106                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a107                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a120                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a121                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a122                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a123                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8384                      
+	ds_write_b64 v4, v[18:19] offset:8416                      
+	v_accvgpr_read_b32 v8, a76                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a77                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a78                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a79                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12416                     
+	ds_write_b64 v4, v[18:19] offset:12448                     
+	v_accvgpr_read_b32 v8, a108                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a109                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a110                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a111                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a124                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a125                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a126                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a127                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12480                     
+	ds_write_b64 v4, v[18:19] offset:12512                     
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 4                                
+	v_add_i32 v4, v4, s62                                      
+	s_mul_i32 s63, s36, 0                                      
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4                                        
+	ds_read_b32 v17, v4 offset:256                             
+	ds_read_b32 v18, v4 offset:512                             
+	ds_read_b32 v19, v4 offset:768                             
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 4                                      
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:1024                            
+	ds_read_b32 v17, v4 offset:1280                            
+	ds_read_b32 v18, v4 offset:1536                            
+	ds_read_b32 v19, v4 offset:1792                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 8                                      
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:2048                            
+	ds_read_b32 v17, v4 offset:2304                            
+	ds_read_b32 v18, v4 offset:2560                            
+	ds_read_b32 v19, v4 offset:2816                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 12                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:3072                            
+	ds_read_b32 v17, v4 offset:3328                            
+	ds_read_b32 v18, v4 offset:3584                            
+	ds_read_b32 v19, v4 offset:3840                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 16                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:4096                            
+	ds_read_b32 v17, v4 offset:4352                            
+	ds_read_b32 v18, v4 offset:4608                            
+	ds_read_b32 v19, v4 offset:4864                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 20                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:5120                            
+	ds_read_b32 v17, v4 offset:5376                            
+	ds_read_b32 v18, v4 offset:5632                            
+	ds_read_b32 v19, v4 offset:5888                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 24                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:6144                            
+	ds_read_b32 v17, v4 offset:6400                            
+	ds_read_b32 v18, v4 offset:6656                            
+	ds_read_b32 v19, v4 offset:6912                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 28                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:7168                            
+	ds_read_b32 v17, v4 offset:7424                            
+	ds_read_b32 v18, v4 offset:7680                            
+	ds_read_b32 v19, v4 offset:7936                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 32                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:8192                            
+	ds_read_b32 v17, v4 offset:8448                            
+	ds_read_b32 v18, v4 offset:8704                            
+	ds_read_b32 v19, v4 offset:8960                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 36                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:9216                            
+	ds_read_b32 v17, v4 offset:9472                            
+	ds_read_b32 v18, v4 offset:9728                            
+	ds_read_b32 v19, v4 offset:9984                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 40                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:10240                           
+	ds_read_b32 v17, v4 offset:10496                           
+	ds_read_b32 v18, v4 offset:10752                           
+	ds_read_b32 v19, v4 offset:11008                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 44                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:11264                           
+	ds_read_b32 v17, v4 offset:11520                           
+	ds_read_b32 v18, v4 offset:11776                           
+	ds_read_b32 v19, v4 offset:12032                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 48                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:12288                           
+	ds_read_b32 v17, v4 offset:12544                           
+	ds_read_b32 v18, v4 offset:12800                           
+	ds_read_b32 v19, v4 offset:13056                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 52                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:13312                           
+	ds_read_b32 v17, v4 offset:13568                           
+	ds_read_b32 v18, v4 offset:13824                           
+	ds_read_b32 v19, v4 offset:14080                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 56                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:14336                           
+	ds_read_b32 v17, v4 offset:14592                           
+	ds_read_b32 v18, v4 offset:14848                           
+	ds_read_b32 v19, v4 offset:15104                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 60                                     
+	v_add_u32_e32 v244, s63, v240                              
+	ds_read_b32 v16, v4 offset:15360                           
+	ds_read_b32 v17, v4 offset:15616                           
+	ds_read_b32 v18, v4 offset:15872                           
+	ds_read_b32 v19, v4 offset:16128                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e64 v4, v4, 8                                
+	v_and_b32_e64 v5, v0, 15                                   
+	v_lshlrev_b32_e32 v5, 8, v5                                
+	v_add_i32 v4, v4, v5                                       
+	s_mul_i32 s62, s46, 0x4000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a128                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a129                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a130                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a131                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a144                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a145                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a146                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a147                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17]                                  
+	ds_write_b64 v4, v[18:19] offset:32                        
+	v_accvgpr_read_b32 v8, a160                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a161                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a162                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a163                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a176                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a177                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a178                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a179                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:64                        
+	ds_write_b64 v4, v[18:19] offset:96                        
+	v_accvgpr_read_b32 v8, a132                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a133                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a134                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a135                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a148                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a149                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a150                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a151                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4096                      
+	ds_write_b64 v4, v[18:19] offset:4128                      
+	v_accvgpr_read_b32 v8, a164                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a165                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a166                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a167                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a180                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a181                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a182                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a183                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4160                      
+	ds_write_b64 v4, v[18:19] offset:4192                      
+	v_accvgpr_read_b32 v8, a136                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a137                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a138                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a139                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a152                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a153                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a154                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a155                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8192                      
+	ds_write_b64 v4, v[18:19] offset:8224                      
+	v_accvgpr_read_b32 v8, a168                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a169                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a170                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a171                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a184                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a185                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a186                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a187                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8256                      
+	ds_write_b64 v4, v[18:19] offset:8288                      
+	v_accvgpr_read_b32 v8, a140                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a141                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a142                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a143                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a156                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a157                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a158                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a159                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12288                     
+	ds_write_b64 v4, v[18:19] offset:12320                     
+	v_accvgpr_read_b32 v8, a172                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a173                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a174                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a175                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a188                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a189                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a190                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a191                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12352                     
+	ds_write_b64 v4, v[18:19] offset:12384                     
+	v_accvgpr_read_b32 v8, a192                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a193                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a194                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a195                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a208                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a209                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a210                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a211                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:128                       
+	ds_write_b64 v4, v[18:19] offset:160                       
+	v_accvgpr_read_b32 v8, a224                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a225                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a226                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a227                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a240                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a241                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a242                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a243                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:192                       
+	ds_write_b64 v4, v[18:19] offset:224                       
+	v_accvgpr_read_b32 v8, a196                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a197                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a198                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a199                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a212                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a213                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a214                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a215                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4224                      
+	ds_write_b64 v4, v[18:19] offset:4256                      
+	v_accvgpr_read_b32 v8, a228                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a229                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a230                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a231                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a244                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a245                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a246                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a247                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:4288                      
+	ds_write_b64 v4, v[18:19] offset:4320                      
+	v_accvgpr_read_b32 v8, a200                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a201                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a202                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a203                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a216                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a217                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a218                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a219                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8320                      
+	ds_write_b64 v4, v[18:19] offset:8352                      
+	v_accvgpr_read_b32 v8, a232                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a233                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a234                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a235                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a248                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a249                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a250                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a251                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:8384                      
+	ds_write_b64 v4, v[18:19] offset:8416                      
+	v_accvgpr_read_b32 v8, a204                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a205                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a206                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a207                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a220                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a221                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a222                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a223                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12416                     
+	ds_write_b64 v4, v[18:19] offset:12448                     
+	v_accvgpr_read_b32 v8, a236                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a237                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a238                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a239                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a252                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a253                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a254                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a255                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	ds_write_b64 v4, v[16:17] offset:12480                     
+	ds_write_b64 v4, v[18:19] offset:12512                     
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 4                                
+	v_add_i32 v4, v4, s62                                      
+	s_mul_i32 s63, s36, 0                                      
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4                                        
+	ds_read_b32 v17, v4 offset:256                             
+	ds_read_b32 v18, v4 offset:512                             
+	ds_read_b32 v19, v4 offset:768                             
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 4                                      
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:1024                            
+	ds_read_b32 v17, v4 offset:1280                            
+	ds_read_b32 v18, v4 offset:1536                            
+	ds_read_b32 v19, v4 offset:1792                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 8                                      
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:2048                            
+	ds_read_b32 v17, v4 offset:2304                            
+	ds_read_b32 v18, v4 offset:2560                            
+	ds_read_b32 v19, v4 offset:2816                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 12                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:3072                            
+	ds_read_b32 v17, v4 offset:3328                            
+	ds_read_b32 v18, v4 offset:3584                            
+	ds_read_b32 v19, v4 offset:3840                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 16                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:4096                            
+	ds_read_b32 v17, v4 offset:4352                            
+	ds_read_b32 v18, v4 offset:4608                            
+	ds_read_b32 v19, v4 offset:4864                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 20                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:5120                            
+	ds_read_b32 v17, v4 offset:5376                            
+	ds_read_b32 v18, v4 offset:5632                            
+	ds_read_b32 v19, v4 offset:5888                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 24                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:6144                            
+	ds_read_b32 v17, v4 offset:6400                            
+	ds_read_b32 v18, v4 offset:6656                            
+	ds_read_b32 v19, v4 offset:6912                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 28                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:7168                            
+	ds_read_b32 v17, v4 offset:7424                            
+	ds_read_b32 v18, v4 offset:7680                            
+	ds_read_b32 v19, v4 offset:7936                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 32                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:8192                            
+	ds_read_b32 v17, v4 offset:8448                            
+	ds_read_b32 v18, v4 offset:8704                            
+	ds_read_b32 v19, v4 offset:8960                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 36                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:9216                            
+	ds_read_b32 v17, v4 offset:9472                            
+	ds_read_b32 v18, v4 offset:9728                            
+	ds_read_b32 v19, v4 offset:9984                            
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 40                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:10240                           
+	ds_read_b32 v17, v4 offset:10496                           
+	ds_read_b32 v18, v4 offset:10752                           
+	ds_read_b32 v19, v4 offset:11008                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 44                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:11264                           
+	ds_read_b32 v17, v4 offset:11520                           
+	ds_read_b32 v18, v4 offset:11776                           
+	ds_read_b32 v19, v4 offset:12032                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 48                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:12288                           
+	ds_read_b32 v17, v4 offset:12544                           
+	ds_read_b32 v18, v4 offset:12800                           
+	ds_read_b32 v19, v4 offset:13056                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 52                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:13312                           
+	ds_read_b32 v17, v4 offset:13568                           
+	ds_read_b32 v18, v4 offset:13824                           
+	ds_read_b32 v19, v4 offset:14080                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 56                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:14336                           
+	ds_read_b32 v17, v4 offset:14592                           
+	ds_read_b32 v18, v4 offset:14848                           
+	ds_read_b32 v19, v4 offset:15104                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_mul_i32 s63, s36, 60                                     
+	v_add_u32_e32 v244, s63, v242                              
+	ds_read_b32 v16, v4 offset:15360                           
+	ds_read_b32 v17, v4 offset:15616                           
+	ds_read_b32 v18, v4 offset:15872                           
+	ds_read_b32 v19, v4 offset:16128                           
+	s_waitcnt lgkmcnt(3)                                       
+	buffer_atomic_pk_add_bf16 v16, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(2)                                       
+	buffer_atomic_pk_add_bf16 v17, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(1)                                       
+	buffer_atomic_pk_add_bf16 v18, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_atomic_pk_add_bf16 v19, v244, s[4:7], 0 offen       
+	v_add_u32_e64 v244, v244, s36                              
+	s_branch label_1BA0                                        
+	
+label_1660:
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a0                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a3                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a16                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a17                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a18                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a19                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a32                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a33                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a34                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a48                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a49                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a50                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a51                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a7                                 
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a20                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a21                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a22                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a23                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a36                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a37                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a38                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a52                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a53                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a54                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a55                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a8                                  
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a9                                  
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a10                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a11                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a40                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a41                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a42                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a43                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v240                              
+	v_accvgpr_read_b32 v8, a12                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a13                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a14                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a15                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a44                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a45                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a46                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a47                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a65                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a66                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a80                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a81                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a82                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a83                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a96                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a97                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a98                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a112                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a113                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a114                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a115                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a69                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a70                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a84                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a85                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a86                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a87                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a100                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a101                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a102                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a103                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a116                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a117                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a118                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a119                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a72                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a73                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a74                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a75                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a104                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a105                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a106                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a107                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a120                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a121                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a122                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a123                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v241                              
+	v_accvgpr_read_b32 v8, a76                                 
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a77                                 
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a78                                
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a79                                
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a108                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a109                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a110                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a111                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a124                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a125                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a126                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a127                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a129                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a130                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a131                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a144                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a145                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a146                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a147                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a160                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a161                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a162                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a163                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a176                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a177                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a178                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a179                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a133                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a134                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a135                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a148                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a149                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a150                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a151                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a164                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a165                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a166                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a167                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a180                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a181                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a182                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a183                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a136                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a137                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a138                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a139                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a152                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a153                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a154                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a155                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a168                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a169                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a170                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a171                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a184                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a185                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a186                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a187                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v242                              
+	v_accvgpr_read_b32 v8, a140                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a141                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a142                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a143                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a156                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a157                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a158                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a159                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a172                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a173                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a174                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a175                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a188                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a189                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a190                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a191                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 0                                      
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a193                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a194                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a195                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a208                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a209                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a210                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a211                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a224                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a225                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a226                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a227                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a240                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a241                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a242                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a243                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a197                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a198                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a199                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a212                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a213                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a214                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a215                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a228                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a229                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a230                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a231                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a244                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a245                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a246                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a247                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 32                                     
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a200                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a201                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a202                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a203                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a216                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a217                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a218                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a219                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a232                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a233                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a234                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a235                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a248                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a249                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a250                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a251                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	s_mul_i32 s62, s36, 48                                     
+	v_add_u32_e32 v244, s62, v243                              
+	v_accvgpr_read_b32 v8, a204                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a205                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a206                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a207                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a220                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a221                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a222                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a223                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	v_accvgpr_read_b32 v8, a236                                
+	v_mul_f32_e32 v8, s41, v8                                  
+	v_accvgpr_read_b32 v9, a237                                
+	v_mul_f32_e32 v9, s41, v9                                  
+	v_accvgpr_read_b32 v10, a238                               
+	v_mul_f32_e32 v10, s41, v10                                
+	v_accvgpr_read_b32 v11, a239                               
+	v_mul_f32_e32 v11, s41, v11                                
+	v_accvgpr_read_b32 v12, a252                               
+	v_mul_f32_e32 v12, s41, v12                                
+	v_accvgpr_read_b32 v13, a253                               
+	v_mul_f32_e32 v13, s41, v13                                
+	v_accvgpr_read_b32 v14, a254                               
+	v_mul_f32_e32 v14, s41, v14                                
+	v_accvgpr_read_b32 v15, a255                               
+	v_mul_f32_e32 v15, s41, v15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v244, s[4:7], 0 offen       
+	v_add_i32 v244, v244, 64                                   
+	
+label_1BA0:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1817,7 +1817,7 @@ label_0E00:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2264,14 +2264,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA.s
@@ -1,0 +1,2282 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x9f                                   
+	s_mov_b32 s63, 0xa0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v162, s62, v161                              
+	v_add_u32_e32 v163, s62, v162                              
+	v_add_u32_e32 v164, s62, v163                              
+	v_add_u32_e32 v165, s62, v164                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v166, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v166, v5, v166                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v166, v6, v166                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v166, v4, v166                               
+	v_add_u32_e32 v166, 0x2000, v166                           
+	v_add_u32_e32 v167, 0x5280, v166                           
+	v_add_u32_e32 v168, 0x5280, v167                           
+	v_add_u32_e32 v169, 0x5280, v168                           
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v170, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v170, s63, v170                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v171, s63, v170                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v172, 2, v0                              
+	v_add_u32_e32 v172, 0, v172                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v173, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v173, s62, v173                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v174, s62, v173                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v175, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v175, s63, v175                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[88:91], v173, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[92:95], v174, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[96:99], v173, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[100:103], v174, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dword v157, v175, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	buffer_load_dword v158, v175, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v175, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(32)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v166                                 
+	ds_read_b128 v[16:19], v166 offset:64                      
+	ds_read_b128 v[12:15], v166 offset:512                     
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v172                                     
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v172 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xa0                                     
+	s_cselect_b32 s62, s62, 0xa0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v176, s36, v5                                 
+	v_add_u32_e32 v176, s62, v176                              
+	v_add_u32_e32 v176, v4, v176                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0711                                  
+	
+label_02B2:
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	ds_read_b32 v154, v172 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:1024                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[72:75], a[64:67], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[76:79], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[72:75], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[76:79], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[80:83], a[64:67], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[84:87], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[80:83], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[84:87], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:2304                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	ds_read_b32 v154, v172 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v173, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v174, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:3072                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v168                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v168 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v168 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v168 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v168 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v168 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v168 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v168 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:4352                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v168 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v168 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v168 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v168 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	ds_read_b32 v154, v172 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v168 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v168 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v168 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v168 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v168 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v168 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v168 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v168 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:5120                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v169                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v169 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v169 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v169 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v169 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v169 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v169 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v169 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:6400                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v169 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v169 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v169 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v169 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	ds_read_b32 v154, v172 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v169 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v169 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v169 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v169 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v169 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v169 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v169 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v169 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:7168                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:256                          
+	s_cbranch_scc0 label_0B70                                  
+	s_branch label_02B2                                        
+	
+label_0711:
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	ds_read_b32 v154, v172 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	ds_read_b32 v155, v172 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	ds_read_b32 v156, v172 offset:1024                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	ds_read_b32 v152, v172 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[72:75], a[64:67], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[76:79], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[72:75], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[76:79], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[80:83], a[64:67], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[84:87], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[80:83], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[84:87], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	ds_read_b32 v153, v172 offset:2304                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	ds_read_b32 v154, v172 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	ds_read_b32 v155, v172 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v173, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v174, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	ds_read_b32 v156, v172 offset:3072                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v168                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v168 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v168 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v168 offset:576                     
+	ds_read_b32 v152, v172 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v168 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v168 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v168 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v168 offset:4800                    
+	ds_read_b32 v153, v172 offset:4352                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v168 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v168 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v168 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v168 offset:9024                    
+	ds_read_b32 v154, v172 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v168 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v168 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v168 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v168 offset:13248                   
+	ds_read_b32 v155, v172 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v168 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v168 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v168 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v168 offset:17472                   
+	ds_read_b32 v156, v172 offset:5120                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v169                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v169 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v169 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v169 offset:576                     
+	ds_read_b32 v152, v172 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v169 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v169 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v169 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v169 offset:4800                    
+	ds_read_b32 v153, v172 offset:6400                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v169 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v169 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v169 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v169 offset:9024                    
+	ds_read_b32 v154, v172 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v169 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v169 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v169 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v169 offset:13248                   
+	ds_read_b32 v155, v172 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v169 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v169 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v169 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v169 offset:17472                   
+	ds_read_b32 v156, v172 offset:7168                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v172                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v172 offset:256                          
+	s_cbranch_scc0 label_0B70                                  
+	s_branch label_0711                                        
+	
+label_0B70:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0CBB                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v180, 0, v176                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	s_branch label_0E00                                        
+	
+label_0CBB:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0E00                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v180, 0, v176                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	
+label_0E00:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB.s
@@ -1,0 +1,2282 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x9f                                   
+	s_mov_b32 s63, 0xa0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v162, s62, v161                              
+	v_add_u32_e32 v163, s62, v162                              
+	v_add_u32_e32 v164, s62, v163                              
+	v_add_u32_e32 v165, s62, v164                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v166, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v166, v5, v166                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v166, v6, v166                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v166, v4, v166                               
+	v_add_u32_e32 v166, 0x2000, v166                           
+	v_add_u32_e32 v167, 0x5280, v166                           
+	v_add_u32_e32 v168, 0x5280, v167                           
+	v_add_u32_e32 v169, 0x5280, v168                           
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v170, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v170, s63, v170                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v171, s63, v170                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v172, 2, v0                              
+	v_add_u32_e32 v172, 0, v172                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v173, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v173, s62, v173                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v174, s62, v173                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v175, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v175, s63, v175                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[88:91], v173, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[92:95], v174, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[96:99], v173, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[100:103], v174, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dword v157, v175, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	buffer_load_dword v158, v175, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v175, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(32)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v166                                 
+	ds_read_b128 v[16:19], v166 offset:64                      
+	ds_read_b128 v[12:15], v166 offset:512                     
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v172                                     
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v172 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xa0                                     
+	s_cselect_b32 s62, s62, 0xa0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v176, s36, v5                                 
+	v_add_u32_e32 v176, s62, v176                              
+	v_add_u32_e32 v176, v4, v176                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0711                                  
+	
+label_02B2:
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	ds_read_b32 v154, v172 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:1024                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[72:75], a[64:67], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[76:79], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[72:75], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[76:79], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[80:83], a[64:67], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[84:87], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[80:83], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[84:87], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:2304                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	ds_read_b32 v154, v172 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v173, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v174, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:3072                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v168                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v168 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v168 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v168 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v168 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v168 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v168 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v168 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:4352                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v168 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v168 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v168 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v168 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	ds_read_b32 v154, v172 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v168 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v168 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v168 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v168 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v168 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v168 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v168 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v168 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:5120                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v169                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v169 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v169 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v169 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v169 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v169 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v169 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v169 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:6400                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v169 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v169 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v169 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v169 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	ds_read_b32 v154, v172 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v169 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v169 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v169 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v169 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v155, v172 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[72:75], v169 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v169 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[76:79], v169 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v169 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v156, v172 offset:7168                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v172                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v153, v172 offset:256                          
+	s_cbranch_scc0 label_0B70                                  
+	s_branch label_02B2                                        
+	
+label_0711:
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	ds_read_b32 v154, v172 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	ds_read_b32 v155, v172 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[40:43], a[32:35], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[44:47], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[40:43], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[44:47], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[48:51], a[32:35], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[52:55], a[36:39], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[48:51], a[40:43], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[52:55], a[44:47], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	ds_read_b32 v156, v172 offset:1024                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[56:59], a[48:51], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[60:63], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[56:59], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[60:63], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[64:67], a[48:51], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[68:71], a[52:55], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[64:67], a[56:59], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[68:71], a[60:63], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	ds_read_b32 v152, v172 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[72:75], a[64:67], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[76:79], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[72:75], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[76:79], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[80:83], a[64:67], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[84:87], a[68:71], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[80:83], a[72:75], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[84:87], a[76:79], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	ds_read_b32 v153, v172 offset:2304                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	ds_read_b32 v154, v172 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	ds_read_b32 v155, v172 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[88:91], v173, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[92:95], v174, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	ds_read_b32 v156, v172 offset:3072                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v168                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v168 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v168 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v168 offset:576                     
+	ds_read_b32 v152, v172 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v168 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v168 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v168 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v168 offset:4800                    
+	ds_read_b32 v153, v172 offset:4352                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v168 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v168 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v168 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v168 offset:9024                    
+	ds_read_b32 v154, v172 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v168 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v168 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v168 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v168 offset:13248                   
+	ds_read_b32 v155, v172 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v168 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v168 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v168 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v168 offset:17472                   
+	ds_read_b32 v156, v172 offset:5120                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v169                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v169 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v169 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v169 offset:576                     
+	ds_read_b32 v152, v172 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v169 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v169 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v169 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v169 offset:4800                    
+	ds_read_b32 v153, v172 offset:6400                         
+	s_cbranch_scc0 label_0B70                                  
+	s_waitcnt vmcnt(24) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v170, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v169 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v171, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v169 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v169 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v169 offset:9024                    
+	ds_read_b32 v154, v172 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v169 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v169 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[60:63], v169 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[68:71], v169 offset:13248                   
+	ds_read_b32 v155, v172 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[72:75], v169 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[80:83], v169 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[76:79], v169 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[84:87], v169 offset:17472                   
+	ds_read_b32 v156, v172 offset:7168                         
+	s_waitcnt vmcnt(29) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v172                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v172 offset:256                          
+	s_cbranch_scc0 label_0B70                                  
+	s_branch label_0711                                        
+	
+label_0B70:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0CBB                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v180, 0, v176                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	s_branch label_0E00                                        
+	
+label_0CBB:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0E00                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v180, 0, v176                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v180, s[4:7], 0 offen       
+	v_add_u32_e32 v180, s62, v180                              
+	
+label_0E00:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1976,7 +1976,7 @@ label_0F3C:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2423,14 +2423,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA.s
@@ -1,0 +1,2441 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x9f                                   
+	s_mov_b32 s63, 0xa0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v162, s62, v161                              
+	v_add_u32_e32 v163, s62, v162                              
+	v_add_u32_e32 v164, s62, v163                              
+	v_add_u32_e32 v165, s62, v164                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v166, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v166, v5, v166                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v166, v6, v166                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v166, v4, v166                               
+	v_add_u32_e32 v166, 0x1000, v166                           
+	v_add_u32_e32 v167, 0x5280, v166                           
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v168, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v168, s63, v168                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v169, s63, v168                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v170, 2, v0                              
+	v_add_u32_e32 v170, 0, v170                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v171, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v171, s62, v171                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v172, s62, v171                              
+	v_add_u32_e32 v173, s62, v172                              
+	v_add_u32_e32 v174, s62, v173                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v175, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v175, s63, v175                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v176, s62, v175                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[88:91], v171, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[92:95], v172, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[96:99], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[100:103], v172, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dword v157, v175, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dword v158, v176, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dwordx4 v[120:123], v171, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	buffer_load_dwordx4 v[124:127], v172, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	buffer_load_dwordx4 v[128:131], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	buffer_load_dwordx4 v[132:135], v172, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v175, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(25)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v166                                 
+	ds_read_b128 v[16:19], v166 offset:64                      
+	ds_read_b128 v[12:15], v166 offset:512                     
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v170                                     
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v170 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xa0                                     
+	s_cselect_b32 s62, s62, 0xa0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v177, s36, v5                                 
+	v_add_u32_e32 v177, s62, v177                              
+	v_add_u32_e32 v177, v4, v177                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_069E                                  
+	
+label_0315:
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v154, v170 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[24:27], a[32:35], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[28:31], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[24:27], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[28:31], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[32:35], a[32:35], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[36:39], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[32:35], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[36:39], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v155, v170 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[40:43], a[64:67], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[44:47], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v176, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[40:43], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[44:47], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[48:51], a[64:67], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[52:55], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[48:51], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[52:55], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v156, v170 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[72:75], a[128:131], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[76:79], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[72:75], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[76:79], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[80:83], a[128:131], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[84:87], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[80:83], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[84:87], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[40:43], a[80:83], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[44:47], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[40:43], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[44:47], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[48:51], a[80:83], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[52:55], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v172, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[48:51], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[52:55], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v170 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[72:75], a[144:147], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[76:79], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[72:75], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[76:79], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[80:83], a[144:147], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[84:87], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[80:83], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[84:87], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v153, v170 offset:2304                         
+	s_cbranch_scc0 label_0A27                                  
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v154, v170 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v155, v170 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v176, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v156, v170 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v171, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v170                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v153, v170 offset:256                          
+	s_cbranch_scc0 label_0A27                                  
+	s_branch label_0315                                        
+	
+label_069E:
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	ds_read_b32 v154, v170 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[24:27], a[32:35], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[28:31], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[24:27], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[28:31], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[32:35], a[32:35], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[36:39], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[32:35], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[36:39], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	ds_read_b32 v155, v170 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[40:43], a[64:67], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v176, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[44:47], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[40:43], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[44:47], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[48:51], a[64:67], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[52:55], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[48:51], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[52:55], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	ds_read_b32 v156, v170 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[72:75], a[128:131], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[76:79], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[72:75], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[76:79], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[80:83], a[128:131], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[84:87], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[80:83], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[84:87], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[40:43], a[80:83], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[44:47], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[40:43], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[44:47], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[48:51], a[80:83], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v172, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[52:55], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[48:51], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[52:55], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	ds_read_b32 v152, v170 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[72:75], a[144:147], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[76:79], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[72:75], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[76:79], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[80:83], a[144:147], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[84:87], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[80:83], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[84:87], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	ds_read_b32 v153, v170 offset:2304                         
+	s_cbranch_scc0 label_0A27                                  
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	ds_read_b32 v154, v170 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	ds_read_b32 v155, v170 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v176, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	ds_read_b32 v156, v170 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v171, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v170                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v170 offset:256                          
+	s_cbranch_scc0 label_0A27                                  
+	s_branch label_069E                                        
+	
+label_0A27:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0CB3                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v181, 0, v177                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_add_u32_e32 v181, 64, v177                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	s_branch label_0F3C                                        
+	
+label_0CB3:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F3C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v181, 0, v177                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F3C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v181, 64, v177                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	
+label_0F3C:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB.s
@@ -1,0 +1,2441 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x9f                                   
+	s_mov_b32 s63, 0xa0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v162, s62, v161                              
+	v_add_u32_e32 v163, s62, v162                              
+	v_add_u32_e32 v164, s62, v163                              
+	v_add_u32_e32 v165, s62, v164                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v166, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v166, v5, v166                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v166, v6, v166                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v166, v4, v166                               
+	v_add_u32_e32 v166, 0x1000, v166                           
+	v_add_u32_e32 v167, 0x5280, v166                           
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v168, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v168, s63, v168                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v169, s63, v168                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v170, 2, v0                              
+	v_add_u32_e32 v170, 0, v170                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v171, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v171, s62, v171                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v172, s62, v171                              
+	v_add_u32_e32 v173, s62, v172                              
+	v_add_u32_e32 v174, s62, v173                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v175, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v175, s63, v175                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v176, s62, v175                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[88:91], v171, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[92:95], v172, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[96:99], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[100:103], v172, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dword v157, v175, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dword v158, v176, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dwordx4 v[120:123], v171, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	buffer_load_dwordx4 v[124:127], v172, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	buffer_load_dwordx4 v[128:131], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	buffer_load_dwordx4 v[132:135], v172, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v175, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(25)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v166                                 
+	ds_read_b128 v[16:19], v166 offset:64                      
+	ds_read_b128 v[12:15], v166 offset:512                     
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v170                                     
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v170 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xa0                                     
+	s_cselect_b32 s62, s62, 0xa0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v177, s36, v5                                 
+	v_add_u32_e32 v177, s62, v177                              
+	v_add_u32_e32 v177, v4, v177                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_069E                                  
+	
+label_0315:
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v154, v170 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[24:27], a[32:35], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[28:31], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[24:27], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[28:31], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[32:35], a[32:35], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[36:39], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[32:35], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[36:39], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v155, v170 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[40:43], a[64:67], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[44:47], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v176, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[40:43], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[44:47], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[48:51], a[64:67], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[52:55], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[48:51], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[52:55], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v156, v170 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[72:75], a[128:131], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[76:79], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[72:75], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[76:79], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[80:83], a[128:131], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[84:87], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[80:83], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[84:87], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[40:43], a[80:83], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[44:47], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[40:43], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[44:47], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[48:51], a[80:83], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[52:55], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v172, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[48:51], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[52:55], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v170 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[72:75], a[144:147], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[76:79], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[72:75], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[76:79], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[80:83], a[144:147], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[84:87], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[80:83], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[84:87], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v153, v170 offset:2304                         
+	s_cbranch_scc0 label_0A27                                  
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v154, v170 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v155, v170 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v176, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v156, v170 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v171, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v152, v170                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v153, v170 offset:256                          
+	s_cbranch_scc0 label_0A27                                  
+	s_branch label_0315                                        
+	
+label_069E:
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[136:139], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v166 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v166 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v166 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v166 offset:9024                    
+	ds_read_b32 v154, v170 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[88:91], v[24:27], a[32:35], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[88:91], v[28:31], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v166 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[92:95], v[24:27], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[92:95], v[28:31], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v166 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[96:99], v[32:35], a[32:35], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[96:99], v[36:39], a[36:39], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v166 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[100:103], v[32:35], a[40:43], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[100:103], v[36:39], a[44:47], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v166 offset:13248                   
+	ds_read_b32 v155, v170 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[40:43], a[64:67], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v176, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[44:47], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[72:75], v166 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[40:43], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[44:47], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[80:83], v166 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[48:51], a[64:67], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[52:55], a[68:71], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v166 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[48:51], a[72:75], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[52:55], a[76:79], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v166 offset:17472                   
+	ds_read_b32 v156, v170 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[72:75], a[128:131], v157, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[76:79], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[72:75], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[76:79], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[80:83], a[128:131], v157, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[84:87], a[132:135], v157, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[80:83], a[136:139], v157, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[84:87], a[140:143], v157, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[40:43], a[80:83], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[88:91], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[44:47], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[40:43], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[44:47], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[48:51], a[80:83], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v172, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[52:55], a[84:87], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[48:51], a[88:91], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[52:55], a[92:95], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v167                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v167 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v167 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v167 offset:576                     
+	ds_read_b32 v152, v170 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[72:75], a[144:147], v158, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[76:79], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v167 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[72:75], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[76:79], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v167 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[80:83], a[144:147], v158, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[84:87], a[148:151], v158, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v167 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[80:83], a[152:155], v158, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[84:87], a[156:159], v158, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v167 offset:4800                    
+	ds_read_b32 v153, v170 offset:2304                         
+	s_cbranch_scc0 label_0A27                                  
+	s_waitcnt vmcnt(17) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v167 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v167 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v167 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v167 offset:9024                    
+	ds_read_b32 v154, v170 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v167 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v167 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v167 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v167 offset:13248                   
+	ds_read_b32 v155, v170 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v176, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[72:75], v167 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[80:83], v167 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v167 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v167 offset:17472                   
+	ds_read_b32 v156, v170 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v168, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v169, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v159, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v159, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v159, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v159, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v159, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(20)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v163, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v164, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v165, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v171, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(22)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v166                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v166 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v166 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v166 offset:576                     
+	ds_read_b32 v152, v170                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v160, v156 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v175, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v166 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v166 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v160, v156 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v160, v156 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v166 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v160, v156 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v160, v156 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v166 offset:4800                    
+	ds_read_b32 v153, v170 offset:256                          
+	s_cbranch_scc0 label_0A27                                  
+	s_branch label_069E                                        
+	
+label_0A27:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0CB3                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v181, 0, v177                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_add_u32_e32 v181, 64, v177                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	s_branch label_0F3C                                        
+	
+label_0CB3:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F3C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v181, 0, v177                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F3C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v181, 64, v177                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v181, s[4:7], 0 offen       
+	v_add_u32_e32 v181, s62, v181                              
+	
+label_0F3C:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2625,7 +2625,7 @@ label_150B:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -3072,14 +3072,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA.s
@@ -1,0 +1,3090 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x9f                                   
+	s_mov_b32 s63, 0xa0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0078:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_007D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0078                                        
+	
+label_007D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0083                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_00A3                                        
+	
+label_0083:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_00A3:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v200, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v200, v5, v200                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v200, v6, v200                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v200, v4, v200                               
+	v_add_u32_e32 v200, 0x1000, v200                           
+	v_add_u32_e32 v201, 0x5280, v200                           
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v202, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v202, s63, v202                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v203, s63, v202                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v204, 2, v0                              
+	v_add_u32_e32 v204, 0, v204                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v205, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v205, s62, v205                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v211, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v211, s63, v211                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[88:91], v205, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[92:95], v206, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[96:99], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[100:103], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v189, v211, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[104:107], v207, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[108:111], v208, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[112:115], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[116:119], v208, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v200                                 
+	ds_read_b128 v[16:19], v200 offset:64                      
+	ds_read_b128 v[12:15], v200 offset:512                     
+	ds_read_b128 v[20:23], v200 offset:576                     
+	ds_read_b32 v184, v204                                     
+	ds_read_b128 v[24:27], v200 offset:4224                    
+	ds_read_b128 v[32:35], v200 offset:4288                    
+	ds_read_b128 v[28:31], v200 offset:4736                    
+	ds_read_b128 v[36:39], v200 offset:4800                    
+	ds_read_b32 v185, v204 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xa0                                     
+	s_cselect_b32 s62, s62, 0xa0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v214, s36, v5                                 
+	v_add_u32_e32 v214, s62, v214                              
+	v_add_u32_e32 v214, v4, v214                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0890                                  
+	
+label_03B3:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v200 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v200 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v200 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v200 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v204 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v200 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v200 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v200 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v200 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v204 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[40:43], a[96:99], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v200 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[44:47], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[40:43], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v200 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[44:47], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[48:51], a[96:99], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v200 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[52:55], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[48:51], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v200 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[52:55], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v204 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[88:91], v[72:75], a[192:195], v189, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[88:91], v[76:79], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[92:95], v[72:75], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[92:95], v[76:79], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[96:99], v[80:83], a[192:195], v189, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[96:99], v[84:87], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[100:103], v[80:83], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[100:103], v[84:87], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[40:43], a[112:115], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[44:47], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[40:43], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[44:47], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[48:51], a[112:115], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[52:55], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[48:51], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[52:55], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[104:107], v[72:75], a[208:211], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[104:107], v[76:79], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[72:75], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[76:79], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[112:115], v[80:83], a[208:211], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[112:115], v[84:87], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[116:119], v[80:83], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[116:119], v[84:87], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[8:11], a[32:35], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[12:15], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[8:11], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[12:15], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[16:19], a[32:35], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[20:23], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[16:19], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[20:23], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[40:43], a[128:131], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[44:47], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[40:43], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[44:47], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[48:51], a[128:131], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[52:55], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[48:51], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[52:55], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v201                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v201 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v201 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v201 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v204 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[120:123], v[72:75], a[224:227], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v201 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[120:123], v[76:79], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[124:127], v[72:75], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v201 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[124:127], v[76:79], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[80:83], a[224:227], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v201 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[84:87], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[132:135], v[80:83], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v201 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[132:135], v[84:87], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v204 offset:2304                         
+	s_cbranch_scc0 label_0D6D                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v201 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v201 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v201 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v201 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v204 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v201 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v201 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v201 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v201 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v204 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[40:43], a[96:99], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v201 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[44:47], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[40:43], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v201 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[44:47], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[48:51], a[96:99], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v201 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[52:55], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v206, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[48:51], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v201 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[52:55], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v204 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[72:75], a[192:195], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[76:79], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[72:75], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[76:79], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[80:83], a[192:195], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[84:87], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[80:83], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[84:87], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[24:27], a[64:67], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[28:31], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[24:27], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[28:31], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[32:35], a[64:67], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[36:39], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[32:35], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[36:39], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[40:43], a[112:115], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[44:47], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[40:43], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[44:47], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[48:51], a[112:115], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[52:55], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[48:51], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[52:55], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[56:59], a[160:163], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[60:63], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[56:59], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[60:63], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[64:67], a[160:163], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[68:71], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[64:67], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[68:71], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[72:75], a[208:211], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[76:79], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[72:75], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[76:79], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[80:83], a[208:211], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[84:87], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[80:83], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[84:87], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[8:11], a[32:35], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[12:15], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[8:11], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[12:15], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[16:19], a[32:35], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[20:23], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[16:19], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[20:23], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[24:27], a[80:83], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[28:31], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[24:27], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[28:31], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[32:35], a[80:83], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[36:39], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[32:35], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[36:39], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[40:43], a[128:131], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[44:47], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[172:175], v[40:43], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[172:175], v[44:47], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[176:179], v[48:51], a[128:131], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[176:179], v[52:55], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[180:183], v[48:51], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[180:183], v[52:55], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[56:59], a[176:179], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v200                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[60:63], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[56:59], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v200 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[60:63], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[64:67], a[176:179], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v200 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[68:71], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[64:67], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v200 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[68:71], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v204                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[72:75], a[224:227], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v200 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[76:79], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[72:75], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v200 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[76:79], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[80:83], a[224:227], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v200 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[84:87], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v200 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v204 offset:256                          
+	s_cbranch_scc0 label_0D6D                                  
+	s_branch label_03B3                                        
+	
+label_0890:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v200 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v200 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v200 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v200 offset:9024                    
+	ds_read_b32 v186, v204 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v200 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v200 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v200 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v200 offset:13248                   
+	ds_read_b32 v187, v204 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[40:43], a[96:99], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[44:47], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v200 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[40:43], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[44:47], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v200 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[48:51], a[96:99], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[52:55], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v200 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[48:51], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[52:55], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v200 offset:17472                   
+	ds_read_b32 v188, v204 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[88:91], v[72:75], a[192:195], v189, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[88:91], v[76:79], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[92:95], v[72:75], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[92:95], v[76:79], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[96:99], v[80:83], a[192:195], v189, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[96:99], v[84:87], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[100:103], v[80:83], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[100:103], v[84:87], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[40:43], a[112:115], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[44:47], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[40:43], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[44:47], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[48:51], a[112:115], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[52:55], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[48:51], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[52:55], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[104:107], v[72:75], a[208:211], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[104:107], v[76:79], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[72:75], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[76:79], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[112:115], v[80:83], a[208:211], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[112:115], v[84:87], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[116:119], v[80:83], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[116:119], v[84:87], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[8:11], a[32:35], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[12:15], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[8:11], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[12:15], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[16:19], a[32:35], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[20:23], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[16:19], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[20:23], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[40:43], a[128:131], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[44:47], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[40:43], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[44:47], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[48:51], a[128:131], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[52:55], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[48:51], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[52:55], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v201                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v201 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v201 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v201 offset:576                     
+	ds_read_b32 v184, v204 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[120:123], v[72:75], a[224:227], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[120:123], v[76:79], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v201 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[124:127], v[72:75], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[124:127], v[76:79], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v201 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[80:83], a[224:227], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[84:87], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v201 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[132:135], v[80:83], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[132:135], v[84:87], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v201 offset:4800                    
+	ds_read_b32 v185, v204 offset:2304                         
+	s_cbranch_scc0 label_0D6D                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v201 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v201 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v201 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v201 offset:9024                    
+	ds_read_b32 v186, v204 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v201 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v201 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v201 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v201 offset:13248                   
+	ds_read_b32 v187, v204 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[40:43], a[96:99], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[44:47], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v201 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[40:43], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[44:47], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v201 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[48:51], a[96:99], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v206, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[52:55], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v201 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[48:51], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[52:55], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v201 offset:17472                   
+	ds_read_b32 v188, v204 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[72:75], a[192:195], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[76:79], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[72:75], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[76:79], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[80:83], a[192:195], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[84:87], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[80:83], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[84:87], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[24:27], a[64:67], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[28:31], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[24:27], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[28:31], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[32:35], a[64:67], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[36:39], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[32:35], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[36:39], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[40:43], a[112:115], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[44:47], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[40:43], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[44:47], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[48:51], a[112:115], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[52:55], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[48:51], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[52:55], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[56:59], a[160:163], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[60:63], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[56:59], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[60:63], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[64:67], a[160:163], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[68:71], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[64:67], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[68:71], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[72:75], a[208:211], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[76:79], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[72:75], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[76:79], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[80:83], a[208:211], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[84:87], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[80:83], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[84:87], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[8:11], a[32:35], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[12:15], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[8:11], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[12:15], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[16:19], a[32:35], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[20:23], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[16:19], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[20:23], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[24:27], a[80:83], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[28:31], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[24:27], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[28:31], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[32:35], a[80:83], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[36:39], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[32:35], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[36:39], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[40:43], a[128:131], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[44:47], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[172:175], v[40:43], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[172:175], v[44:47], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[176:179], v[48:51], a[128:131], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[176:179], v[52:55], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[180:183], v[48:51], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[180:183], v[52:55], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[56:59], a[176:179], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[60:63], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v200                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[56:59], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[60:63], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v200 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[64:67], a[176:179], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[68:71], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v200 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[64:67], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[68:71], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v200 offset:576                     
+	ds_read_b32 v184, v204                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[72:75], a[224:227], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[76:79], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v200 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[72:75], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[76:79], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v200 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[80:83], a[224:227], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[84:87], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v200 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v200 offset:4800                    
+	ds_read_b32 v185, v204 offset:256                          
+	s_cbranch_scc0 label_0D6D                                  
+	s_branch label_0890                                        
+	
+label_0D6D:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_113D                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v218, 0, v214                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_add_u32_e32 v218, 64, v214                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_add_u32_e32 v218, 0x80, v214                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	s_branch label_150B                                        
+	
+label_113D:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_150B                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v218, 0, v214                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_150B                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v218, 64, v214                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_150B                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v218, 0x80, v214                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	
+label_150B:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB.s
@@ -1,0 +1,3090 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x9f                                   
+	s_mov_b32 s63, 0xa0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0078:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_007D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0078                                        
+	
+label_007D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0083                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_00A3                                        
+	
+label_0083:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_00A3:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v200, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v200, v5, v200                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v200, v6, v200                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v200, v4, v200                               
+	v_add_u32_e32 v200, 0x1000, v200                           
+	v_add_u32_e32 v201, 0x5280, v200                           
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xa0                                     
+	s_cselect_b32 s62, s63, 0xa0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v202, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v202, s63, v202                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v203, s63, v202                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v204, 2, v0                              
+	v_add_u32_e32 v204, 0, v204                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v205, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v205, s62, v205                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v211, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v211, s63, v211                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[88:91], v205, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[92:95], v206, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[96:99], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[100:103], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v189, v211, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[104:107], v207, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[108:111], v208, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[112:115], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[116:119], v208, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v200                                 
+	ds_read_b128 v[16:19], v200 offset:64                      
+	ds_read_b128 v[12:15], v200 offset:512                     
+	ds_read_b128 v[20:23], v200 offset:576                     
+	ds_read_b32 v184, v204                                     
+	ds_read_b128 v[24:27], v200 offset:4224                    
+	ds_read_b128 v[32:35], v200 offset:4288                    
+	ds_read_b128 v[28:31], v200 offset:4736                    
+	ds_read_b128 v[36:39], v200 offset:4800                    
+	ds_read_b32 v185, v204 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xa0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xa0                                     
+	s_cselect_b32 s62, s62, 0xa0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v214, s36, v5                                 
+	v_add_u32_e32 v214, s62, v214                              
+	v_add_u32_e32 v214, v4, v214                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0890                                  
+	
+label_03B3:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v200 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v200 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v200 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v200 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v204 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v200 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v200 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v200 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v200 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v204 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[40:43], a[96:99], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v200 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[44:47], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[40:43], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v200 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[44:47], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[48:51], a[96:99], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v200 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[52:55], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[48:51], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v200 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[52:55], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v204 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[88:91], v[72:75], a[192:195], v189, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[88:91], v[76:79], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[92:95], v[72:75], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[92:95], v[76:79], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[96:99], v[80:83], a[192:195], v189, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[96:99], v[84:87], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[100:103], v[80:83], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[100:103], v[84:87], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[40:43], a[112:115], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[44:47], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[40:43], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[44:47], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[48:51], a[112:115], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[52:55], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[48:51], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[52:55], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[104:107], v[72:75], a[208:211], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[104:107], v[76:79], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[72:75], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[76:79], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[112:115], v[80:83], a[208:211], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[112:115], v[84:87], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[116:119], v[80:83], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[116:119], v[84:87], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[8:11], a[32:35], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[12:15], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[8:11], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[12:15], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[16:19], a[32:35], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[20:23], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[16:19], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[20:23], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[40:43], a[128:131], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[44:47], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[40:43], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[44:47], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[48:51], a[128:131], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[52:55], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[48:51], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[52:55], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v201                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v201 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v201 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v201 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v204 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[120:123], v[72:75], a[224:227], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v201 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[120:123], v[76:79], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[124:127], v[72:75], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v201 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[124:127], v[76:79], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[80:83], a[224:227], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v201 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[84:87], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[132:135], v[80:83], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v201 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[132:135], v[84:87], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v204 offset:2304                         
+	s_cbranch_scc0 label_0D6D                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v201 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v201 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v201 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v201 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v204 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v201 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v201 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v201 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v201 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v204 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[40:43], a[96:99], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v201 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[44:47], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[40:43], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v201 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[44:47], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[48:51], a[96:99], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v201 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[52:55], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v206, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[48:51], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v201 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[52:55], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v204 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[72:75], a[192:195], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[76:79], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[72:75], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[76:79], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[80:83], a[192:195], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[84:87], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[80:83], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[84:87], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[24:27], a[64:67], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[28:31], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[24:27], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[28:31], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[32:35], a[64:67], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[36:39], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[32:35], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[36:39], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[40:43], a[112:115], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[44:47], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[40:43], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[44:47], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[48:51], a[112:115], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[52:55], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[48:51], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[52:55], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[56:59], a[160:163], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[60:63], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[56:59], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[60:63], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[64:67], a[160:163], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[68:71], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[64:67], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[68:71], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[72:75], a[208:211], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[76:79], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[72:75], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[76:79], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[80:83], a[208:211], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[84:87], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[80:83], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[84:87], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[8:11], a[32:35], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[12:15], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[8:11], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[12:15], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[16:19], a[32:35], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[20:23], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[16:19], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[20:23], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[24:27], a[80:83], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[28:31], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[24:27], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[28:31], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[32:35], a[80:83], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[36:39], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[32:35], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[36:39], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[40:43], a[128:131], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[44:47], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[172:175], v[40:43], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[172:175], v[44:47], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[176:179], v[48:51], a[128:131], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[176:179], v[52:55], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[180:183], v[48:51], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[180:183], v[52:55], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[56:59], a[176:179], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v200                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[60:63], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[56:59], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v200 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[60:63], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[64:67], a[176:179], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v200 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[68:71], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[64:67], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v200 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[68:71], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v204                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[72:75], a[224:227], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v200 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[76:79], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[72:75], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v200 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[76:79], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[80:83], a[224:227], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v200 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[84:87], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v200 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v204 offset:256                          
+	s_cbranch_scc0 label_0D6D                                  
+	s_branch label_03B3                                        
+	
+label_0890:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[8:11], a[0:3], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[12:15], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v200 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[8:11], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[12:15], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v200 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[16:19], a[0:3], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[20:23], a[4:7], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v200 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[16:19], a[8:11], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[20:23], a[12:15], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v200 offset:9024                    
+	ds_read_b32 v186, v204 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v200 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v200 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v200 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v200 offset:13248                   
+	ds_read_b32 v187, v204 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[40:43], a[96:99], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[44:47], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v200 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[40:43], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[44:47], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v200 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[48:51], a[96:99], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[52:55], a[100:103], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v200 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[48:51], a[104:107], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[52:55], a[108:111], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v200 offset:17472                   
+	ds_read_b32 v188, v204 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[88:91], v[72:75], a[192:195], v189, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[88:91], v[76:79], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[92:95], v[72:75], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[92:95], v[76:79], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[96:99], v[80:83], a[192:195], v189, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[96:99], v[84:87], a[196:199], v189, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[100:103], v[80:83], a[200:203], v189, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[100:103], v[84:87], a[204:207], v189, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[8:11], a[16:19], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[12:15], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[8:11], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[12:15], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[16:19], a[16:19], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[20:23], a[20:23], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[16:19], a[24:27], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[20:23], a[28:31], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[40:43], a[112:115], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[44:47], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[40:43], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[44:47], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[48:51], a[112:115], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[52:55], a[116:119], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[48:51], a[120:123], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[52:55], a[124:127], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[104:107], v[72:75], a[208:211], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[104:107], v[76:79], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[108:111], v[72:75], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[108:111], v[76:79], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[112:115], v[80:83], a[208:211], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[112:115], v[84:87], a[212:215], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[116:119], v[80:83], a[216:219], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[116:119], v[84:87], a[220:223], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[8:11], a[32:35], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[12:15], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[8:11], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[12:15], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[16:19], a[32:35], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[20:23], a[36:39], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[16:19], a[40:43], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[20:23], a[44:47], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[40:43], a[128:131], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[44:47], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[40:43], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[44:47], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[48:51], a[128:131], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[52:55], a[132:135], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[48:51], a[136:139], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[52:55], a[140:143], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v201                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v201 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v201 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v201 offset:576                     
+	ds_read_b32 v184, v204 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[120:123], v[72:75], a[224:227], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[120:123], v[76:79], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v201 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[124:127], v[72:75], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[124:127], v[76:79], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v201 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[128:131], v[80:83], a[224:227], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[128:131], v[84:87], a[228:231], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v201 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[132:135], v[80:83], a[232:235], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[132:135], v[84:87], a[236:239], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v201 offset:4800                    
+	ds_read_b32 v185, v204 offset:2304                         
+	s_cbranch_scc0 label_0D6D                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v202, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v201 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v201 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v203, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v201 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v201 offset:9024                    
+	ds_read_b32 v186, v204 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v201 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v201 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v201 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v201 offset:13248                   
+	ds_read_b32 v187, v204 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[40:43], a[96:99], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[44:47], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v201 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[40:43], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[44:47], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v201 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[48:51], a[96:99], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v206, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[52:55], a[100:103], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v201 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[48:51], a[104:107], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[52:55], a[108:111], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v201 offset:17472                   
+	ds_read_b32 v188, v204 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[72:75], a[192:195], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[76:79], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[72:75], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[76:79], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[80:83], a[192:195], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[84:87], a[196:199], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[80:83], a[200:203], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[84:87], a[204:207], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[24:27], a[64:67], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[28:31], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[24:27], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[28:31], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[32:35], a[64:67], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[104:107], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[36:39], a[68:71], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[32:35], a[72:75], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[36:39], a[76:79], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[40:43], a[112:115], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[44:47], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[40:43], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[44:47], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[48:51], a[112:115], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[52:55], a[116:119], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[48:51], a[120:123], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[52:55], a[124:127], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[56:59], a[160:163], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[60:63], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[56:59], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[60:63], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[64:67], a[160:163], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[68:71], a[164:167], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[64:67], a[168:171], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[68:71], a[172:175], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[72:75], a[208:211], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[76:79], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[72:75], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[76:79], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[80:83], a[208:211], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[84:87], a[212:215], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[80:83], a[216:219], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[84:87], a[220:223], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(17)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[8:11], a[32:35], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[12:15], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[8:11], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[12:15], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[16:19], a[32:35], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[20:23], a[36:39], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[16:19], a[40:43], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[20:23], a[44:47], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[24:27], a[80:83], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[28:31], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[24:27], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[28:31], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[32:35], a[80:83], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[36:39], a[84:87], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[32:35], a[88:91], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[36:39], a[92:95], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[40:43], a[128:131], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[44:47], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[172:175], v[40:43], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[172:175], v[44:47], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[176:179], v[48:51], a[128:131], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[176:179], v[52:55], a[132:135], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[180:183], v[48:51], a[136:139], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[180:183], v[52:55], a[140:143], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[56:59], a[176:179], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[60:63], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v200                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[56:59], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[60:63], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v200 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[64:67], a[176:179], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[68:71], a[180:183], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v200 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[64:67], a[184:187], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[68:71], a[188:191], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v200 offset:576                     
+	ds_read_b32 v184, v204                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[72:75], a[224:227], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[76:79], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v200 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[72:75], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[76:79], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v200 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[80:83], a[224:227], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[84:87], a[228:231], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v200 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v200 offset:4800                    
+	ds_read_b32 v185, v204 offset:256                          
+	s_cbranch_scc0 label_0D6D                                  
+	s_branch label_0890                                        
+	
+label_0D6D:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_113D                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v218, 0, v214                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_add_u32_e32 v218, 64, v214                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_add_u32_e32 v218, 0x80, v214                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	s_branch label_150B                                        
+	
+label_113D:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_150B                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v218, 0, v214                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_150B                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v218, 64, v214                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_150B                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v218, 0x80, v214                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	v_add_u32_e32 v218, s62, v218                              
+	
+label_150B:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_160x384_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2044,7 +2044,7 @@ label_1025:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2491,14 +2491,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA.s
@@ -1,0 +1,2509 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0xbf                                   
+	s_mov_b32 s63, 0xc0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	v_add_u32_e32 v182, s62, v181                              
+	v_add_u32_e32 v183, s62, v182                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v184, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v184, v5, v184                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v184, v6, v184                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v184, v4, v184                               
+	v_add_u32_e32 v184, 0x2000, v184                           
+	v_add_u32_e32 v185, 0x6300, v184                           
+	v_add_u32_e32 v186, 0x6300, v185                           
+	v_add_u32_e32 v187, 0x6300, v186                           
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v188, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v188, s63, v188                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v189, s63, v188                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v190, 2, v0                              
+	v_add_u32_e32 v190, 0, v190                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v191, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v191, s62, v191                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v192, s62, v191                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v193, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v193, s63, v193                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[104:107], v191, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[108:111], v192, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[112:115], v191, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[116:119], v192, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v193, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[136:139], v191, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[140:143], v192, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[144:147], v191, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(35)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v184                                 
+	ds_read_b128 v[16:19], v184 offset:64                      
+	ds_read_b128 v[12:15], v184 offset:512                     
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v190                                     
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v190 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xc0                                     
+	s_cselect_b32 s62, s62, 0xc0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v194, s36, v5                                 
+	v_add_u32_e32 v194, s62, v194                              
+	v_add_u32_e32 v194, v4, v194                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_07FA                                  
+	
+label_02DF:
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	ds_read_b32 v170, v190 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	ds_read_b32 v171, v190 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:1280                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v185 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[88:91], a[80:83], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[92:95], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[88:91], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[92:95], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[96:99], a[80:83], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[100:103], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[96:99], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[100:103], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:2304                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	ds_read_b32 v170, v190 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	ds_read_b32 v171, v190 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[108:111], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[112:115], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:3328                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v186                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v186 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v186 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v186 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v186 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v186 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v186 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v186 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:4352                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v186 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v186 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v186 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v186 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	ds_read_b32 v170, v190 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v186 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v186 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v186 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v186 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	ds_read_b32 v171, v190 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v186 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v186 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v186 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v186 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v186 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v186 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v186 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v186 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:5376                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v187                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v187 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v187 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v187 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v187 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v187 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v187 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v187 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:6400                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v187 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v187 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v187 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v187 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	ds_read_b32 v170, v190 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v187 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v187 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v187 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v187 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	ds_read_b32 v171, v190 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v187 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v187 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v187 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[140:143], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v187 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v187 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[144:147], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v187 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v187 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v187 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:7424                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:256                          
+	s_cbranch_scc0 label_0D15                                  
+	s_branch label_02DF                                        
+	
+label_07FA:
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	ds_read_b32 v170, v190 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	ds_read_b32 v171, v190 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	ds_read_b32 v172, v190 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	ds_read_b32 v173, v190 offset:1280                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v185 offset:576                     
+	ds_read_b32 v168, v190 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[88:91], a[80:83], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[92:95], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[88:91], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[92:95], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[96:99], a[80:83], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[100:103], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[96:99], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[100:103], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	ds_read_b32 v169, v190 offset:2304                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	ds_read_b32 v170, v190 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	ds_read_b32 v171, v190 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[108:111], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	ds_read_b32 v172, v190 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[112:115], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	ds_read_b32 v173, v190 offset:3328                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v186                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v186 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v186 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v186 offset:576                     
+	ds_read_b32 v168, v190 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v186 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v186 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v186 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v186 offset:4800                    
+	ds_read_b32 v169, v190 offset:4352                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v186 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v186 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v186 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v186 offset:9024                    
+	ds_read_b32 v170, v190 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v186 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v186 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v186 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v186 offset:13248                   
+	ds_read_b32 v171, v190 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v186 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v186 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v186 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v186 offset:17472                   
+	ds_read_b32 v172, v190 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v186 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v186 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v186 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v186 offset:21696                 
+	ds_read_b32 v173, v190 offset:5376                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v187                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v187 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v187 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v187 offset:576                     
+	ds_read_b32 v168, v190 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v187 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v187 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v187 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v187 offset:4800                    
+	ds_read_b32 v169, v190 offset:6400                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v187 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v187 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v187 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v187 offset:9024                    
+	ds_read_b32 v170, v190 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v187 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v187 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v187 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v187 offset:13248                   
+	ds_read_b32 v171, v190 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v187 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v187 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[140:143], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v187 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v187 offset:17472                   
+	ds_read_b32 v172, v190 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[144:147], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v187 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v187 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v187 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v187 offset:21696                 
+	ds_read_b32 v173, v190 offset:7424                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v190                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v190 offset:256                          
+	s_cbranch_scc0 label_0D15                                  
+	s_branch label_07FA                                        
+	
+label_0D15:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0EA0                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_branch label_1025                                        
+	
+label_0EA0:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1025                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	
+label_1025:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB.s
@@ -1,0 +1,2509 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0xbf                                   
+	s_mov_b32 s63, 0xc0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	v_add_u32_e32 v182, s62, v181                              
+	v_add_u32_e32 v183, s62, v182                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v184, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v184, v5, v184                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v184, v6, v184                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v184, v4, v184                               
+	v_add_u32_e32 v184, 0x2000, v184                           
+	v_add_u32_e32 v185, 0x6300, v184                           
+	v_add_u32_e32 v186, 0x6300, v185                           
+	v_add_u32_e32 v187, 0x6300, v186                           
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v188, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v188, s63, v188                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v189, s63, v188                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v190, 2, v0                              
+	v_add_u32_e32 v190, 0, v190                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v191, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v191, s62, v191                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v192, s62, v191                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v193, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v193, s63, v193                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dwordx4 v[104:107], v191, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[108:111], v192, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[112:115], v191, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[116:119], v192, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v193, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[136:139], v191, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[140:143], v192, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[144:147], v191, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(35)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v184                                 
+	ds_read_b128 v[16:19], v184 offset:64                      
+	ds_read_b128 v[12:15], v184 offset:512                     
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v190                                     
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v190 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xc0                                     
+	s_cselect_b32 s62, s62, 0xc0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v194, s36, v5                                 
+	v_add_u32_e32 v194, s62, v194                              
+	v_add_u32_e32 v194, v4, v194                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_07FA                                  
+	
+label_02DF:
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	ds_read_b32 v170, v190 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	ds_read_b32 v171, v190 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:1280                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v185 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[88:91], a[80:83], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[92:95], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[88:91], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[92:95], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[96:99], a[80:83], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[100:103], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[96:99], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[100:103], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:2304                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	ds_read_b32 v170, v190 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	ds_read_b32 v171, v190 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[108:111], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[112:115], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:3328                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v186                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v186 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v186 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v186 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v186 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v186 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v186 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v186 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:4352                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v186 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v186 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v186 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v186 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	ds_read_b32 v170, v190 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v186 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v186 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v186 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v186 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	ds_read_b32 v171, v190 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v186 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v186 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v186 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v186 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v186 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v186 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v186 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v186 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:5376                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v187                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v187 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v187 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v187 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v187 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v187 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v187 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v187 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:6400                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v187 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v187 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v187 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v187 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	ds_read_b32 v170, v190 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v187 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v187 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v187 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v187 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	ds_read_b32 v171, v190 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[72:75], v187 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[80:83], v187 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[76:79], v187 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[140:143], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[84:87], v187 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b32 v172, v190 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[88:91], v187 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[144:147], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v187 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v187 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v187 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v190 offset:7424                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v168, v190                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v190 offset:256                          
+	s_cbranch_scc0 label_0D15                                  
+	s_branch label_02DF                                        
+	
+label_07FA:
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	ds_read_b32 v170, v190 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	ds_read_b32 v171, v190 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	ds_read_b32 v172, v190 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[56:59], a[48:51], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[60:63], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[56:59], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[60:63], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[64:67], a[48:51], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[68:71], a[52:55], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[64:67], a[56:59], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[68:71], a[60:63], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	ds_read_b32 v173, v190 offset:1280                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v185 offset:576                     
+	ds_read_b32 v168, v190 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[88:91], a[80:83], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[92:95], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[88:91], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[92:95], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[96:99], a[80:83], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[100:103], a[84:87], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[96:99], a[88:91], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[100:103], a[92:95], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	ds_read_b32 v169, v190 offset:2304                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	ds_read_b32 v170, v190 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	ds_read_b32 v171, v190 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[108:111], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	ds_read_b32 v172, v190 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[112:115], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	ds_read_b32 v173, v190 offset:3328                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v186                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v186 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v186 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v186 offset:576                     
+	ds_read_b32 v168, v190 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v186 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v186 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v186 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v186 offset:4800                    
+	ds_read_b32 v169, v190 offset:4352                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v186 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v186 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v186 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v186 offset:9024                    
+	ds_read_b32 v170, v190 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v186 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v186 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v186 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v186 offset:13248                   
+	ds_read_b32 v171, v190 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v186 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v186 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v186 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v186 offset:17472                   
+	ds_read_b32 v172, v190 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v186 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v186 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v186 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v186 offset:21696                 
+	ds_read_b32 v173, v190 offset:5376                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v187                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v187 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v187 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v187 offset:576                     
+	ds_read_b32 v168, v190 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v187 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v187 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v187 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v187 offset:4800                    
+	ds_read_b32 v169, v190 offset:6400                         
+	s_cbranch_scc0 label_0D15                                  
+	s_waitcnt vmcnt(26) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v188, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v187 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v189, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v187 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v187 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v187 offset:9024                    
+	ds_read_b32 v170, v190 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v187 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v187 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v187 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[68:71], v187 offset:13248                   
+	ds_read_b32 v171, v190 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[72:75], v187 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[80:83], v187 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[140:143], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b128 v[76:79], v187 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[84:87], v187 offset:17472                   
+	ds_read_b32 v172, v190 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[144:147], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[88:91], v187 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v187 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v187 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v187 offset:21696                 
+	ds_read_b32 v173, v190 offset:7424                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v190                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v190 offset:256                          
+	s_cbranch_scc0 label_0D15                                  
+	s_branch label_07FA                                        
+	
+label_0D15:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0EA0                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_branch label_1025                                        
+	
+label_0EA0:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1025                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	
+label_1025:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1863,7 +1863,7 @@ label_0BB4:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2310,14 +2310,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA.s
@@ -1,0 +1,2328 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s63, 0xc0, 8                                     
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s43, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s43, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 3                                     
+	s_cmp_lt_i32 s3, s62                                       
+	s_cbranch_scc0 label_0072                                  
+	s_add_u32 s49, s44, 0xff                                   
+	s_lshr_b32 s48, s49, 8                                     
+	s_mul_i32 s49, s48, s3                                     
+	s_add_i32 s49, s49, s2                                     
+	s_lshr_b32 s63, s44, 13                                    
+	s_lshl_b32 s47, s63, 5                                     
+	s_mul_i32 s62, s62, s47                                    
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc0 label_0068                                  
+	s_and_b32 s62, s49, 0xff                                   
+	s_and_b32 s47, s62, 31                                     
+	s_lshr_b32 s48, s62, 5                                     
+	s_lshr_b32 s49, s49, 8                                     
+	
+label_0060:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0065                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 8                                      
+	s_branch label_0060                                        
+	
+label_0065:
+	s_mul_i32 s49, s49, 32                                     
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0068:
+	s_sub_i32 s49, s49, s62                                    
+	s_sub_i32 s63, s48, s47                                    
+	s_mov_b32 s48, 0                                           
+	
+label_006B:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0070                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 1                                      
+	s_branch label_006B                                        
+	
+label_0070:
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0072:
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	
+label_0074:
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	v_add_u32_e32 v182, s62, v181                              
+	v_add_u32_e32 v183, s62, v182                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v184, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v184, v5, v184                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v184, v6, v184                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v184, v4, v184                               
+	v_add_u32_e32 v184, 0x1000, v184                           
+	v_add_u32_e32 v185, 0x6300, v184                           
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v186, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v186, s63, v186                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v187, s63, v186                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v188, 2, v0                              
+	v_add_u32_e32 v188, 0, v188                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v189, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v189, s62, v189                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v193, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v193, s63, v193                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v194, s62, v193                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	s_waitcnt vmcnt(27)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v184                                 
+	ds_read_b128 v[16:19], v184 offset:64                      
+	ds_read_b128 v[12:15], v184 offset:512                     
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v188                                     
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v188 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_and_b32 s5, s5, 0xffff                                   
+	s_or_b32 s5, s5, 0x40000                                   
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xc0                                     
+	s_cselect_b32 s62, s62, 0xc0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s62, s62, s63                                    
+	s_mov_b32 s6, s62                                          
+	s_mov_b32 s7, 0x20000                                      
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_mul_lo_u32 v195, v4, s36                                 
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_and_b32_e32 v4, 7, v0                                    
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v4, s62, v4                                  
+	v_add_u32_e32 v195, v195, v4                               
+	s_mul_i32 s62, s36, 8                                      
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	v_add_u32_e32 v202, s62, v201                              
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_078D                                  
+	
+label_0366:
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v188 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v188 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v172, v188 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v188 offset:1280                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[72:75], a[128:131], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[76:79], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[72:75], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[76:79], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[80:83], a[128:131], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[84:87], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[80:83], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[84:87], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[72:75], a[144:147], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[76:79], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[72:75], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[76:79], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[80:83], a[144:147], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[84:87], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[80:83], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v185 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[84:87], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v188 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v188 offset:2304                         
+	s_cbranch_scc0 label_0BB4                                  
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v188 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[24:27], a[32:35], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[28:31], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[24:27], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[28:31], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[32:35], a[32:35], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[36:39], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[32:35], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[36:39], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v188 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v172, v188 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[56:59], a[96:99], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[60:63], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[56:59], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[60:63], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[64:67], a[96:99], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[68:71], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[64:67], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[68:71], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v188 offset:3328                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[72:75], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[76:79], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[80:83], a[128:131], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[84:87], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[80:83], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[84:87], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[24:27], a[48:51], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[28:31], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[24:27], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[28:31], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[32:35], a[48:51], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[36:39], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[56:59], a[112:115], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[60:63], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[56:59], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[60:63], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[64:67], a[112:115], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[68:71], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[72:75], a[144:147], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[76:79], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[72:75], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[76:79], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[160:163], v[80:83], a[144:147], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[160:163], v[84:87], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[164:167], v[80:83], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[164:167], v[84:87], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v188                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v188 offset:256                          
+	s_cbranch_scc0 label_0BB4                                  
+	s_branch label_0366                                        
+	
+label_078D:
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	ds_read_b32 v170, v188 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	ds_read_b32 v171, v188 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	ds_read_b32 v172, v188 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	ds_read_b32 v173, v188 offset:1280                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[72:75], a[128:131], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[76:79], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[72:75], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[76:79], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[80:83], a[128:131], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[84:87], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[80:83], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[84:87], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[72:75], a[144:147], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[76:79], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[72:75], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[76:79], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[80:83], a[144:147], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[84:87], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[80:83], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[84:87], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v185 offset:576                     
+	ds_read_b32 v168, v188 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	ds_read_b32 v169, v188 offset:2304                         
+	s_cbranch_scc0 label_0BB4                                  
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	ds_read_b32 v170, v188 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[24:27], a[32:35], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[28:31], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[24:27], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[28:31], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[32:35], a[32:35], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[36:39], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[32:35], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[36:39], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	ds_read_b32 v171, v188 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	ds_read_b32 v172, v188 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[56:59], a[96:99], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[60:63], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[56:59], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[60:63], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[64:67], a[96:99], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[68:71], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[64:67], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[68:71], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	ds_read_b32 v173, v188 offset:3328                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[72:75], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[76:79], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[80:83], a[128:131], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[84:87], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[80:83], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[84:87], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[24:27], a[48:51], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[28:31], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[24:27], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[28:31], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[32:35], a[48:51], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[36:39], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[56:59], a[112:115], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[60:63], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[56:59], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[60:63], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[64:67], a[112:115], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[68:71], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[72:75], a[144:147], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[76:79], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[72:75], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[76:79], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[160:163], v[80:83], a[144:147], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[160:163], v[84:87], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[164:167], v[80:83], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[164:167], v[84:87], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v188                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v188 offset:256                          
+	s_cbranch_scc0 label_0BB4                                  
+	s_branch label_078D                                        
+	
+label_0BB4:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_barrier                                                  
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_i32_i24_e32 v5, 0x80, v5                             
+	v_add_u32_e32 v4, v4, v5                                   
+	s_mul_i32 s62, s46, 0x6000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19]                                 
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:64                       
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2048                     
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2112                     
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4096                     
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4160                     
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6144                     
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6208                     
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8192                     
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8256                     
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10240                    
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10304                    
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12288                    
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12352                    
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14336                    
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14400                    
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16384                    
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16448                    
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18432                    
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18496                    
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20480                    
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20544                    
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22528                    
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22592                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 16                               
+	v_add_i32 v4, v4, s62                                      
+	ds_read_b128 v[16:19], v4                                  
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v195, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:1024                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v196, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:2048                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:3072                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:4096                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:5120                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v200, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:6144                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:7168                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v202, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:8192                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v203, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:9216                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v204, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:10240                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v205, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:11264                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:12288                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:13312                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v208, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:14336                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v209, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:15360                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v210, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:16384                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v211, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:17408                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v212, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:18432                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v213, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:19456                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v214, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:20480                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v215, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:21504                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:22528                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v217, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:23552                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB.s
@@ -1,0 +1,2328 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s63, 0xc0, 8                                     
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s43, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s43, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 3                                     
+	s_cmp_lt_i32 s3, s62                                       
+	s_cbranch_scc0 label_0072                                  
+	s_add_u32 s49, s44, 0xff                                   
+	s_lshr_b32 s48, s49, 8                                     
+	s_mul_i32 s49, s48, s3                                     
+	s_add_i32 s49, s49, s2                                     
+	s_lshr_b32 s63, s44, 13                                    
+	s_lshl_b32 s47, s63, 5                                     
+	s_mul_i32 s62, s62, s47                                    
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc0 label_0068                                  
+	s_and_b32 s62, s49, 0xff                                   
+	s_and_b32 s47, s62, 31                                     
+	s_lshr_b32 s48, s62, 5                                     
+	s_lshr_b32 s49, s49, 8                                     
+	
+label_0060:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0065                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 8                                      
+	s_branch label_0060                                        
+	
+label_0065:
+	s_mul_i32 s49, s49, 32                                     
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0068:
+	s_sub_i32 s49, s49, s62                                    
+	s_sub_i32 s63, s48, s47                                    
+	s_mov_b32 s48, 0                                           
+	
+label_006B:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0070                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 1                                      
+	s_branch label_006B                                        
+	
+label_0070:
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0072:
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	
+label_0074:
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	v_add_u32_e32 v182, s62, v181                              
+	v_add_u32_e32 v183, s62, v182                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v184, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v184, v5, v184                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v184, v6, v184                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v184, v4, v184                               
+	v_add_u32_e32 v184, 0x1000, v184                           
+	v_add_u32_e32 v185, 0x6300, v184                           
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xc0                                     
+	s_cselect_b32 s62, s63, 0xc0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v186, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v186, s63, v186                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v187, s63, v186                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v188, 2, v0                              
+	v_add_u32_e32 v188, 0, v188                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v189, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v189, s62, v189                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v193, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v193, s63, v193                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v194, s62, v193                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(27)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v184                                 
+	ds_read_b128 v[16:19], v184 offset:64                      
+	ds_read_b128 v[12:15], v184 offset:512                     
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v188                                     
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v188 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_and_b32 s5, s5, 0xffff                                   
+	s_or_b32 s5, s5, 0x40000                                   
+	s_mul_i32 s62, s48, 0xc0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xc0                                     
+	s_cselect_b32 s62, s62, 0xc0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s62, s62, s63                                    
+	s_mov_b32 s6, s62                                          
+	s_mov_b32 s7, 0x20000                                      
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_mul_lo_u32 v195, v4, s36                                 
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_and_b32_e32 v4, 7, v0                                    
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v4, s62, v4                                  
+	v_add_u32_e32 v195, v195, v4                               
+	s_mul_i32 s62, s36, 8                                      
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	v_add_u32_e32 v202, s62, v201                              
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_078D                                  
+	
+label_0366:
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v188 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v188 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v172, v188 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v188 offset:1280                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[72:75], a[128:131], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[76:79], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[72:75], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[76:79], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[80:83], a[128:131], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[84:87], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[80:83], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[84:87], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[72:75], a[144:147], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[76:79], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[72:75], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[76:79], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[80:83], a[144:147], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[84:87], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[80:83], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v185 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[84:87], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v188 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v188 offset:2304                         
+	s_cbranch_scc0 label_0BB4                                  
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v188 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[24:27], a[32:35], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[28:31], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[24:27], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[28:31], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[32:35], a[32:35], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[36:39], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[32:35], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[36:39], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v188 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v172, v188 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[56:59], a[96:99], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[60:63], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[56:59], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[60:63], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[64:67], a[96:99], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[68:71], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[64:67], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[68:71], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v188 offset:3328                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[72:75], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[76:79], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[80:83], a[128:131], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[84:87], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[80:83], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[84:87], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[24:27], a[48:51], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[28:31], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[24:27], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[28:31], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[32:35], a[48:51], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[36:39], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[56:59], a[112:115], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[60:63], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[56:59], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[60:63], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[64:67], a[112:115], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[68:71], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[72:75], a[144:147], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[76:79], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[72:75], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[76:79], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[160:163], v[80:83], a[144:147], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[160:163], v[84:87], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[164:167], v[80:83], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[164:167], v[84:87], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v188                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v188 offset:256                          
+	s_cbranch_scc0 label_0BB4                                  
+	s_branch label_0366                                        
+	
+label_078D:
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v184 offset:9024                    
+	ds_read_b32 v170, v188 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v184 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v184 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:13248                   
+	ds_read_b32 v171, v188 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v184 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v184 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v184 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v184 offset:17472                   
+	ds_read_b32 v172, v188 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v184 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:21696                 
+	ds_read_b32 v173, v188 offset:1280                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[72:75], a[128:131], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[76:79], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[72:75], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[76:79], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[80:83], a[128:131], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[84:87], a[132:135], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[80:83], a[136:139], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[84:87], a[140:143], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[72:75], a[144:147], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[76:79], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v185                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[72:75], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[76:79], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v185 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[80:83], a[144:147], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[84:87], a[148:151], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v185 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[80:83], a[152:155], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[84:87], a[156:159], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v185 offset:576                     
+	ds_read_b32 v168, v188 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v185 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v185 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v185 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v185 offset:4800                    
+	ds_read_b32 v169, v188 offset:2304                         
+	s_cbranch_scc0 label_0BB4                                  
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v185 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v185 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v185 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v185 offset:9024                    
+	ds_read_b32 v170, v188 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[24:27], a[32:35], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[28:31], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v185 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[24:27], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[28:31], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v185 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[32:35], a[32:35], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[36:39], a[36:39], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v185 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[32:35], a[40:43], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[36:39], a[44:47], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v185 offset:13248                   
+	ds_read_b32 v171, v188 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v185 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v185 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v185 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v185 offset:17472                   
+	ds_read_b32 v172, v188 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[56:59], a[96:99], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[60:63], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v185 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[56:59], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[60:63], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v185 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[64:67], a[96:99], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[68:71], a[100:103], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v185 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[64:67], a[104:107], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[68:71], a[108:111], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v185 offset:21696                 
+	ds_read_b32 v173, v188 offset:3328                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v186, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[72:75], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[76:79], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[80:83], a[128:131], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v187, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[84:87], a[132:135], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[80:83], a[136:139], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[84:87], a[140:143], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[8:11], a[16:19], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[12:15], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[8:11], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[12:15], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[16:19], a[16:19], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v181, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[20:23], a[20:23], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[16:19], a[24:27], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[20:23], a[28:31], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[24:27], a[48:51], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v182, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[28:31], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[24:27], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[28:31], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[32:35], a[48:51], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v183, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[36:39], a[52:55], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[32:35], a[56:59], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[36:39], a[60:63], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[56:59], a[112:115], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[60:63], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[56:59], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[60:63], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[64:67], a[112:115], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[68:71], a[116:119], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[72:75], a[144:147], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[76:79], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v184                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[156:159], v[72:75], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[156:159], v[76:79], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[160:163], v[80:83], a[144:147], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[160:163], v[84:87], a[148:151], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[164:167], v[80:83], a[152:155], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[164:167], v[84:87], a[156:159], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v184 offset:576                     
+	ds_read_b32 v168, v188                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v184 offset:4800                    
+	ds_read_b32 v169, v188 offset:256                          
+	s_cbranch_scc0 label_0BB4                                  
+	s_branch label_078D                                        
+	
+label_0BB4:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_barrier                                                  
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_i32_i24_e32 v5, 0x80, v5                             
+	v_add_u32_e32 v4, v4, v5                                   
+	s_mul_i32 s62, s46, 0x6000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19]                                 
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:64                       
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2048                     
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2112                     
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4096                     
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4160                     
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6144                     
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6208                     
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8192                     
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8256                     
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10240                    
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10304                    
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12288                    
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12352                    
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14336                    
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14400                    
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16384                    
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16448                    
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18432                    
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18496                    
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20480                    
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20544                    
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22528                    
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22592                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 16                               
+	v_add_i32 v4, v4, s62                                      
+	ds_read_b128 v[16:19], v4                                  
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v195, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:1024                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v196, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:2048                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:3072                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:4096                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v199, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:5120                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v200, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:6144                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:7168                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v202, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:8192                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v203, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:9216                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v204, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:10240                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v205, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:11264                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:12288                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:13312                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v208, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:14336                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v209, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:15360                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v210, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:16384                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v211, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:17408                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v212, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:18432                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v213, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:19456                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v214, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:20480                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v215, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:21504                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:22528                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v217, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:23552                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_192x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2271,7 +2271,7 @@ label_124A:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2718,14 +2718,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA.s
@@ -1,0 +1,2736 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0xdf                                   
+	s_mov_b32 s63, 0xe0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v202, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v202, v5, v202                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v202, v6, v202                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v202, v4, v202                               
+	v_add_u32_e32 v202, 0x2000, v202                           
+	v_add_u32_e32 v203, 0x7380, v202                           
+	v_add_u32_e32 v204, 0x7380, v203                           
+	v_add_u32_e32 v205, 0x7380, v204                           
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v206, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v206, s63, v206                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v207, s63, v206                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v208, 2, v0                              
+	v_add_u32_e32 v208, 0, v208                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v209, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v209, s62, v209                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v210, s62, v209                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v211, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v211, s63, v211                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v191, v211, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v211, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[152:155], v209, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[156:159], v210, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[160:163], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[164:167], v210, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v211, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(38)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v202                                 
+	ds_read_b128 v[16:19], v202 offset:64                      
+	ds_read_b128 v[12:15], v202 offset:512                     
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v208                                     
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v208 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xe0                                     
+	s_cselect_b32 s62, s62, 0xe0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v212, s36, v5                                 
+	v_add_u32_e32 v212, s62, v212                              
+	v_add_u32_e32 v212, v4, v212                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_08E3                                  
+	
+label_030C:
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:1536                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[104:107], a[96:99], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[108:111], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[104:107], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[108:111], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[112:115], a[96:99], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[116:119], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[112:115], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[116:119], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:2304                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:3584                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v204                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v204 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v204 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v204 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v204 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v204 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v204 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v204 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:4352                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v204 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v204 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v204 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v204 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v204 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v204 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v204 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v204 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v204 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v204 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v204 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v204 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v204 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v204 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v204 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v204 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v204 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v204 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v204 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v204 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:5632                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v205                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v205 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v205 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v205 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v205 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v205 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v205 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v205 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:6400                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v205 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v205 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v205 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v205 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v205 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v205 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v205 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v205 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v205 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v205 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v205 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v205 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v205 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v205 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v205 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v205 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v205 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v205 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v205 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v205 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:7680                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:256                          
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_branch label_030C                                        
+	
+label_08E3:
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	ds_read_b32 v186, v208 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	ds_read_b32 v187, v208 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	ds_read_b32 v188, v208 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	ds_read_b32 v189, v208 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	ds_read_b32 v190, v208 offset:1536                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	ds_read_b32 v184, v208 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[104:107], a[96:99], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[108:111], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[104:107], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[108:111], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[112:115], a[96:99], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[116:119], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[112:115], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[116:119], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	ds_read_b32 v185, v208 offset:2304                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	ds_read_b32 v186, v208 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	ds_read_b32 v187, v208 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	ds_read_b32 v188, v208 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	ds_read_b32 v189, v208 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	ds_read_b32 v190, v208 offset:3584                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v204                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v204 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v204 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v204 offset:576                     
+	ds_read_b32 v184, v208 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v204 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v204 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v204 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v204 offset:4800                    
+	ds_read_b32 v185, v208 offset:4352                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v204 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v204 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v204 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v204 offset:9024                    
+	ds_read_b32 v186, v208 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v204 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v204 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v204 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v204 offset:13248                   
+	ds_read_b32 v187, v208 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v204 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v204 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v204 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v204 offset:17472                   
+	ds_read_b32 v188, v208 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v204 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v204 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v204 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v204 offset:21696                 
+	ds_read_b32 v189, v208 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v204 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v204 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v204 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v204 offset:25920                 
+	ds_read_b32 v190, v208 offset:5632                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v205                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v205 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v205 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v205 offset:576                     
+	ds_read_b32 v184, v208 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v205 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v205 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v205 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v205 offset:4800                    
+	ds_read_b32 v185, v208 offset:6400                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v205 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v205 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v205 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v205 offset:9024                    
+	ds_read_b32 v186, v208 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v205 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v205 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v205 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v205 offset:13248                   
+	ds_read_b32 v187, v208 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v205 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v205 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v205 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v205 offset:17472                   
+	ds_read_b32 v188, v208 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v205 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v205 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v205 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v205 offset:21696                 
+	ds_read_b32 v189, v208 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v205 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v205 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v205 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v205 offset:25920                 
+	ds_read_b32 v190, v208 offset:7680                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v208                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v208 offset:256                          
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_branch label_08E3                                        
+	
+label_0EBA:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_1085                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v216, 0, v212                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	s_branch label_124A                                        
+	
+label_1085:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_124A                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v216, 0, v212                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	
+label_124A:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB.s
@@ -1,0 +1,2736 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0xdf                                   
+	s_mov_b32 s63, 0xe0                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v202, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v202, v5, v202                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v202, v6, v202                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v202, v4, v202                               
+	v_add_u32_e32 v202, 0x2000, v202                           
+	v_add_u32_e32 v203, 0x7380, v202                           
+	v_add_u32_e32 v204, 0x7380, v203                           
+	v_add_u32_e32 v205, 0x7380, v204                           
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v206, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v206, s63, v206                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v207, s63, v206                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v208, 2, v0                              
+	v_add_u32_e32 v208, 0, v208                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v209, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v209, s62, v209                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v210, s62, v209                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v211, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v211, s63, v211                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v191, v211, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v211, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[152:155], v209, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[156:159], v210, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[160:163], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[164:167], v210, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v211, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(38)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v202                                 
+	ds_read_b128 v[16:19], v202 offset:64                      
+	ds_read_b128 v[12:15], v202 offset:512                     
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v208                                     
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v208 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xe0                                     
+	s_cselect_b32 s62, s62, 0xe0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v212, s36, v5                                 
+	v_add_u32_e32 v212, s62, v212                              
+	v_add_u32_e32 v212, v4, v212                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_08E3                                  
+	
+label_030C:
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:1536                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[104:107], a[96:99], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[108:111], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[104:107], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[108:111], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[112:115], a[96:99], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[116:119], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[112:115], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[116:119], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:2304                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:3584                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v204                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v204 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v204 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v204 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v204 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v204 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v204 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v204 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:4352                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v204 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v204 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v204 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v204 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v204 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v204 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v204 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v204 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v204 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v204 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v204 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v204 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v204 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v204 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v204 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v204 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v204 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v204 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v204 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v204 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:5632                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v205                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v205 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v205 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v205 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v205 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v205 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v205 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v205 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:6400                         
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v205 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v205 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v205 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v205 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v208 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v205 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v205 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v205 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v205 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v208 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v205 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v205 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v205 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v205 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v208 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v205 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v205 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v205 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v205 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v208 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v205 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[112:115], v205 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[108:111], v205 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[116:119], v205 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	ds_read_b32 v190, v208 offset:7680                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v208                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v185, v208 offset:256                          
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_branch label_030C                                        
+	
+label_08E3:
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	ds_read_b32 v186, v208 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	ds_read_b32 v187, v208 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[40:43], a[32:35], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[44:47], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[40:43], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[44:47], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[48:51], a[32:35], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[52:55], a[36:39], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[48:51], a[40:43], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[52:55], a[44:47], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	ds_read_b32 v188, v208 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	ds_read_b32 v189, v208 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[72:75], a[64:67], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[76:79], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[72:75], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[76:79], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[80:83], a[64:67], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[84:87], a[68:71], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[80:83], a[72:75], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[84:87], a[76:79], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	ds_read_b32 v190, v208 offset:1536                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[88:91], a[80:83], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[92:95], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[88:91], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[92:95], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[96:99], a[80:83], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[100:103], a[84:87], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[96:99], a[88:91], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[100:103], a[92:95], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	ds_read_b32 v184, v208 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[104:107], a[96:99], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[108:111], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[104:107], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[108:111], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[112:115], a[96:99], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[116:119], a[100:103], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[112:115], a[104:107], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[116:119], a[108:111], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	ds_read_b32 v185, v208 offset:2304                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	ds_read_b32 v186, v208 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	ds_read_b32 v187, v208 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	ds_read_b32 v188, v208 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	ds_read_b32 v189, v208 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[120:123], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	ds_read_b32 v190, v208 offset:3584                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[124:127], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v204                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v204 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v204 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v204 offset:576                     
+	ds_read_b32 v184, v208 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v204 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v204 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v204 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v204 offset:4800                    
+	ds_read_b32 v185, v208 offset:4352                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v204 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v204 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v204 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v204 offset:9024                    
+	ds_read_b32 v186, v208 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v204 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v204 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v204 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v204 offset:13248                   
+	ds_read_b32 v187, v208 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v204 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v204 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v204 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v204 offset:17472                   
+	ds_read_b32 v188, v208 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v204 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v204 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v204 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v204 offset:21696                 
+	ds_read_b32 v189, v208 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v204 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v204 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v204 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v204 offset:25920                 
+	ds_read_b32 v190, v208 offset:5632                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v205                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v205 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v205 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v205 offset:576                     
+	ds_read_b32 v184, v208 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v205 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v205 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v205 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v205 offset:4800                    
+	ds_read_b32 v185, v208 offset:6400                         
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_waitcnt vmcnt(28) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v206, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v205 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v205 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v207, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v205 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v205 offset:9024                    
+	ds_read_b32 v186, v208 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v205 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v205 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v205 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v205 offset:13248                   
+	ds_read_b32 v187, v208 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v205 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v205 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v205 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v205 offset:17472                   
+	ds_read_b32 v188, v208 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v205 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v205 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v205 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v205 offset:21696                 
+	ds_read_b32 v189, v208 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[104:107], v205 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[112:115], v205 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[108:111], v205 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[116:119], v205 offset:25920                 
+	ds_read_b32 v190, v208 offset:7680                         
+	s_waitcnt vmcnt(34) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v208                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v208 offset:256                          
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0EBA                                  
+	s_branch label_08E3                                        
+	
+label_0EBA:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_1085                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v216, 0, v212                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	s_branch label_124A                                        
+	
+label_1085:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_124A                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v216, 0, v212                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	v_add_u32_e32 v216, s62, v216                              
+	
+label_124A:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_224x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2084,7 +2084,7 @@ label_0D3D:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2531,14 +2531,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA.s
@@ -1,0 +1,2549 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s63, 0xe0, 8                                     
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s43, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s43, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 3                                     
+	s_cmp_lt_i32 s3, s62                                       
+	s_cbranch_scc0 label_0072                                  
+	s_add_u32 s49, s44, 0xff                                   
+	s_lshr_b32 s48, s49, 8                                     
+	s_mul_i32 s49, s48, s3                                     
+	s_add_i32 s49, s49, s2                                     
+	s_lshr_b32 s63, s44, 13                                    
+	s_lshl_b32 s47, s63, 5                                     
+	s_mul_i32 s62, s62, s47                                    
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc0 label_0068                                  
+	s_and_b32 s62, s49, 0xff                                   
+	s_and_b32 s47, s62, 31                                     
+	s_lshr_b32 s48, s62, 5                                     
+	s_lshr_b32 s49, s49, 8                                     
+	
+label_0060:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0065                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 8                                      
+	s_branch label_0060                                        
+	
+label_0065:
+	s_mul_i32 s49, s49, 32                                     
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0068:
+	s_sub_i32 s49, s49, s62                                    
+	s_sub_i32 s63, s48, s47                                    
+	s_mov_b32 s48, 0                                           
+	
+label_006B:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0070                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 1                                      
+	s_branch label_006B                                        
+	
+label_0070:
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0072:
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	
+label_0074:
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v202, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v202, v5, v202                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v202, v6, v202                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v202, v4, v202                               
+	v_add_u32_e32 v202, 0x1000, v202                           
+	v_add_u32_e32 v203, 0x7380, v202                           
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v204, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v204, s63, v204                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v205, s63, v204                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v206, 2, v0                              
+	v_add_u32_e32 v206, 0, v206                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v207, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v207, s62, v207                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v211, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v211, s63, v211                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v212, s62, v211                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dword v191, v211, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dword v192, v212, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v211, s[24:27], 0 offen            
+	s_waitcnt vmcnt(29)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v202                                 
+	ds_read_b128 v[16:19], v202 offset:64                      
+	ds_read_b128 v[12:15], v202 offset:512                     
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v206                                     
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v206 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_and_b32 s5, s5, 0xffff                                   
+	s_or_b32 s5, s5, 0x40000                                   
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xe0                                     
+	s_cselect_b32 s62, s62, 0xe0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s62, s62, s63                                    
+	s_mov_b32 s6, s62                                          
+	s_mov_b32 s7, 0x20000                                      
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_mul_lo_u32 v213, v4, s36                                 
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_and_b32_e32 v4, 7, v0                                    
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v4, s62, v4                                  
+	v_add_u32_e32 v213, v213, v4                               
+	s_mul_i32 s62, s36, 8                                      
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	v_add_u32_e32 v225, s62, v224                              
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	v_add_u32_e32 v228, s62, v227                              
+	v_add_u32_e32 v229, s62, v228                              
+	v_add_u32_e32 v230, s62, v229                              
+	v_add_u32_e32 v231, s62, v230                              
+	v_add_u32_e32 v232, s62, v231                              
+	v_add_u32_e32 v233, s62, v232                              
+	v_add_u32_e32 v234, s62, v233                              
+	v_add_u32_e32 v235, s62, v234                              
+	v_add_u32_e32 v236, s62, v235                              
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	v_add_u32_e32 v240, s62, v239                              
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0878                                  
+	
+label_03B3:
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v206 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v206 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v188, v206 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v206 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v190, v206 offset:1536                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[88:91], a[160:163], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[92:95], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[88:91], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[92:95], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[96:99], a[160:163], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[100:103], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[96:99], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[100:103], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[104:107], a[192:195], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[108:111], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[124:127], v[104:107], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[124:127], v[108:111], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[128:131], v[112:115], a[192:195], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[128:131], v[116:119], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[132:135], v[112:115], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[132:135], v[116:119], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[88:91], a[176:179], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[92:95], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[88:91], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[92:95], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[96:99], a[176:179], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[100:103], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[96:99], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[100:103], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v206 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[136:139], v[104:107], a[208:211], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[136:139], v[108:111], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[140:143], v[104:107], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[140:143], v[108:111], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[112:115], a[208:211], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[116:119], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[148:151], v[112:115], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[148:151], v[116:119], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v206 offset:2304                         
+	s_cbranch_scc0 label_0D3D                                  
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v206 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v206 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[40:43], a[64:67], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[44:47], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[40:43], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[44:47], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[48:51], a[64:67], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[52:55], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[48:51], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[52:55], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v188, v206 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[56:59], a[96:99], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[60:63], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[56:59], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[60:63], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[64:67], a[96:99], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[68:71], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[64:67], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[68:71], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v206 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v190, v206 offset:3584                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[88:91], a[160:163], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[92:95], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[88:91], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[92:95], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[96:99], a[160:163], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[100:103], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[96:99], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[100:103], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[104:107], a[192:195], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[108:111], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[104:107], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[108:111], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[112:115], a[192:195], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[116:119], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[112:115], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[116:119], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[8:11], a[16:19], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[12:15], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[8:11], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[12:15], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[16:19], a[16:19], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[20:23], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[16:19], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[20:23], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[24:27], a[48:51], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[28:31], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[24:27], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[28:31], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[32:35], a[48:51], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[36:39], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[32:35], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[36:39], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[40:43], a[80:83], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[44:47], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[40:43], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[44:47], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[48:51], a[80:83], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[52:55], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[48:51], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[52:55], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[56:59], a[112:115], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[60:63], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[56:59], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[60:63], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[64:67], a[112:115], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[68:71], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[64:67], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[68:71], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[88:91], a[176:179], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[92:95], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[88:91], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[92:95], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[96:99], a[176:179], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[100:103], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[96:99], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[100:103], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v206                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[104:107], a[208:211], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[108:111], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[104:107], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[108:111], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[112:115], a[208:211], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[116:119], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[112:115], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[116:119], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v206 offset:256                          
+	s_cbranch_scc0 label_0D3D                                  
+	s_branch label_03B3                                        
+	
+label_0878:
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	ds_read_b32 v186, v206 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	ds_read_b32 v187, v206 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	ds_read_b32 v188, v206 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	ds_read_b32 v189, v206 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	ds_read_b32 v190, v206 offset:1536                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[88:91], a[160:163], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[92:95], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[88:91], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[92:95], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[96:99], a[160:163], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[100:103], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[96:99], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[100:103], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[104:107], a[192:195], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[108:111], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[124:127], v[104:107], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[124:127], v[108:111], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[128:131], v[112:115], a[192:195], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[128:131], v[116:119], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[132:135], v[112:115], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[132:135], v[116:119], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[88:91], a[176:179], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[92:95], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[88:91], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[92:95], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[96:99], a[176:179], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[100:103], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[96:99], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[100:103], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	ds_read_b32 v184, v206 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[136:139], v[104:107], a[208:211], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[136:139], v[108:111], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[140:143], v[104:107], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[140:143], v[108:111], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[112:115], a[208:211], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[116:119], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[148:151], v[112:115], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[148:151], v[116:119], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	ds_read_b32 v185, v206 offset:2304                         
+	s_cbranch_scc0 label_0D3D                                  
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	ds_read_b32 v186, v206 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	ds_read_b32 v187, v206 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[40:43], a[64:67], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[44:47], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[40:43], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[44:47], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[48:51], a[64:67], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[52:55], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[48:51], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[52:55], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	ds_read_b32 v188, v206 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[56:59], a[96:99], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[60:63], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[56:59], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[60:63], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[64:67], a[96:99], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[68:71], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[64:67], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[68:71], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	ds_read_b32 v189, v206 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	ds_read_b32 v190, v206 offset:3584                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[88:91], a[160:163], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[92:95], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[88:91], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[92:95], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[96:99], a[160:163], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[100:103], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[96:99], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[100:103], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[104:107], a[192:195], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[108:111], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[104:107], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[108:111], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[112:115], a[192:195], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[116:119], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[112:115], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[116:119], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[8:11], a[16:19], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[12:15], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[8:11], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[12:15], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[16:19], a[16:19], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[20:23], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[16:19], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[20:23], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[24:27], a[48:51], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[28:31], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[24:27], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[28:31], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[32:35], a[48:51], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[36:39], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[32:35], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[36:39], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[40:43], a[80:83], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[44:47], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[40:43], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[44:47], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[48:51], a[80:83], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[52:55], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[48:51], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[52:55], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[56:59], a[112:115], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[60:63], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[56:59], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[60:63], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[64:67], a[112:115], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[68:71], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[64:67], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[68:71], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[88:91], a[176:179], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[92:95], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[88:91], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[92:95], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[96:99], a[176:179], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[100:103], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[96:99], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[100:103], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v206                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[104:107], a[208:211], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[108:111], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[104:107], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[108:111], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[112:115], a[208:211], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[116:119], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[112:115], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[116:119], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v206 offset:256                          
+	s_cbranch_scc0 label_0D3D                                  
+	s_branch label_0878                                        
+	
+label_0D3D:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_barrier                                                  
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_i32_i24_e32 v5, 0x80, v5                             
+	v_add_u32_e32 v4, v4, v5                                   
+	s_mul_i32 s62, s46, 0x7000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19]                                 
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:64                       
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2048                     
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2112                     
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4096                     
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4160                     
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6144                     
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6208                     
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8192                     
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8256                     
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10240                    
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10304                    
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12288                    
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12352                    
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14336                    
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14400                    
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16384                    
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16448                    
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18432                    
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18496                    
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20480                    
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20544                    
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22528                    
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22592                    
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:24576                    
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:24640                    
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:26624                    
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:26688                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 16                               
+	v_add_i32 v4, v4, s62                                      
+	ds_read_b128 v[16:19], v4                                  
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v213, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:1024                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v214, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:2048                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v215, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:3072                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:4096                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v217, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:5120                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:6144                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v219, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:7168                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v220, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:8192                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:9216                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v222, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:10240                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v223, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:11264                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v224, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:12288                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v225, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:13312                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:14336                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:15360                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v228, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:16384                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v229, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:17408                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v230, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:18432                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v231, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:19456                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:20480                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v233, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:21504                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:22528                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v235, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:23552                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v236, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:24576                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v237, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:25600                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v238, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:26624                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v239, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:27648                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v240, s[4:7], 0 offen       
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB.s
@@ -1,0 +1,2549 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s63, 0xe0, 8                                     
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s43, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s43, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 3                                     
+	s_cmp_lt_i32 s3, s62                                       
+	s_cbranch_scc0 label_0072                                  
+	s_add_u32 s49, s44, 0xff                                   
+	s_lshr_b32 s48, s49, 8                                     
+	s_mul_i32 s49, s48, s3                                     
+	s_add_i32 s49, s49, s2                                     
+	s_lshr_b32 s63, s44, 13                                    
+	s_lshl_b32 s47, s63, 5                                     
+	s_mul_i32 s62, s62, s47                                    
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc0 label_0068                                  
+	s_and_b32 s62, s49, 0xff                                   
+	s_and_b32 s47, s62, 31                                     
+	s_lshr_b32 s48, s62, 5                                     
+	s_lshr_b32 s49, s49, 8                                     
+	
+label_0060:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0065                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 8                                      
+	s_branch label_0060                                        
+	
+label_0065:
+	s_mul_i32 s49, s49, 32                                     
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0068:
+	s_sub_i32 s49, s49, s62                                    
+	s_sub_i32 s63, s48, s47                                    
+	s_mov_b32 s48, 0                                           
+	
+label_006B:
+	s_cmp_lt_i32 s49, s63                                      
+	s_cbranch_scc1 label_0070                                  
+	s_sub_i32 s49, s49, s63                                    
+	s_add_i32 s48, s48, 1                                      
+	s_branch label_006B                                        
+	
+label_0070:
+	s_add_i32 s47, s47, s49                                    
+	s_branch label_0074                                        
+	
+label_0072:
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	
+label_0074:
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v202, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v202, v5, v202                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v202, v6, v202                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v202, v4, v202                               
+	v_add_u32_e32 v202, 0x1000, v202                           
+	v_add_u32_e32 v203, 0x7380, v202                           
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0xe0                                     
+	s_cselect_b32 s62, s63, 0xe0                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v204, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v204, s63, v204                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v205, s63, v204                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v206, 2, v0                              
+	v_add_u32_e32 v206, 0, v206                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v207, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v207, s62, v207                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v211, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v211, s63, v211                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v212, s62, v211                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dword v191, v211, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dword v192, v212, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v211, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(29)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v202                                 
+	ds_read_b128 v[16:19], v202 offset:64                      
+	ds_read_b128 v[12:15], v202 offset:512                     
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v206                                     
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v206 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_and_b32 s5, s5, 0xffff                                   
+	s_or_b32 s5, s5, 0x40000                                   
+	s_mul_i32 s62, s48, 0xe0                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0xe0                                     
+	s_cselect_b32 s62, s62, 0xe0                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s62, s62, s63                                    
+	s_mov_b32 s6, s62                                          
+	s_mov_b32 s7, 0x20000                                      
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_mul_lo_u32 v213, v4, s36                                 
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_and_b32_e32 v4, 7, v0                                    
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v4, s62, v4                                  
+	v_add_u32_e32 v213, v213, v4                               
+	s_mul_i32 s62, s36, 8                                      
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	v_add_u32_e32 v225, s62, v224                              
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	v_add_u32_e32 v228, s62, v227                              
+	v_add_u32_e32 v229, s62, v228                              
+	v_add_u32_e32 v230, s62, v229                              
+	v_add_u32_e32 v231, s62, v230                              
+	v_add_u32_e32 v232, s62, v231                              
+	v_add_u32_e32 v233, s62, v232                              
+	v_add_u32_e32 v234, s62, v233                              
+	v_add_u32_e32 v235, s62, v234                              
+	v_add_u32_e32 v236, s62, v235                              
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	v_add_u32_e32 v240, s62, v239                              
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0878                                  
+	
+label_03B3:
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v206 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v206 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v188, v206 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v206 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v190, v206 offset:1536                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[88:91], a[160:163], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[92:95], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[88:91], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[92:95], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[96:99], a[160:163], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[100:103], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[96:99], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[100:103], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[104:107], a[192:195], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[108:111], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[124:127], v[104:107], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[124:127], v[108:111], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[128:131], v[112:115], a[192:195], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[128:131], v[116:119], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[132:135], v[112:115], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[132:135], v[116:119], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[88:91], a[176:179], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[92:95], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[88:91], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[92:95], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[96:99], a[176:179], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[100:103], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[96:99], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[100:103], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v206 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[136:139], v[104:107], a[208:211], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[136:139], v[108:111], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[140:143], v[104:107], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[140:143], v[108:111], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[112:115], a[208:211], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[116:119], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[148:151], v[112:115], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[148:151], v[116:119], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v206 offset:2304                         
+	s_cbranch_scc0 label_0D3D                                  
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v206 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v206 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[40:43], a[64:67], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[44:47], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[40:43], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[44:47], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[48:51], a[64:67], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[52:55], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[48:51], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[52:55], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b32 v188, v206 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[56:59], a[96:99], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[60:63], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[56:59], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[60:63], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[64:67], a[96:99], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[68:71], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[64:67], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[68:71], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v206 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v190, v206 offset:3584                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[88:91], a[160:163], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[92:95], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[88:91], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[92:95], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[96:99], a[160:163], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[100:103], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[96:99], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[100:103], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[104:107], a[192:195], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[108:111], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[104:107], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[108:111], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[112:115], a[192:195], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[116:119], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[112:115], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[116:119], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[8:11], a[16:19], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[12:15], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[8:11], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[12:15], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[16:19], a[16:19], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[20:23], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[16:19], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[20:23], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[24:27], a[48:51], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[28:31], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[24:27], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[28:31], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[32:35], a[48:51], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[36:39], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[32:35], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[36:39], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[40:43], a[80:83], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[44:47], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[40:43], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[44:47], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[48:51], a[80:83], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[52:55], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[48:51], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[52:55], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[56:59], a[112:115], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[60:63], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[56:59], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[60:63], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[64:67], a[112:115], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[68:71], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[64:67], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[68:71], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[88:91], a[176:179], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[92:95], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[88:91], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[92:95], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[96:99], a[176:179], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[100:103], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[96:99], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[100:103], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v206                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[104:107], a[208:211], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[108:111], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[104:107], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[108:111], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[112:115], a[208:211], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[116:119], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[112:115], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[116:119], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v206 offset:256                          
+	s_cbranch_scc0 label_0D3D                                  
+	s_branch label_03B3                                        
+	
+label_0878:
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[8:11], a[0:3], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[12:15], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v202 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[8:11], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[12:15], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v202 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[16:19], a[0:3], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[20:23], a[4:7], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v202 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[16:19], a[8:11], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[20:23], a[12:15], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v202 offset:9024                    
+	ds_read_b32 v186, v206 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[24:27], a[32:35], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[28:31], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v202 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[24:27], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[28:31], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v202 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[32:35], a[32:35], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[36:39], a[36:39], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v202 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[32:35], a[40:43], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[36:39], a[44:47], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v202 offset:13248                   
+	ds_read_b32 v187, v206 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[40:43], a[64:67], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[44:47], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v202 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[40:43], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[44:47], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v202 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[48:51], a[64:67], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[52:55], a[68:71], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v202 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[48:51], a[72:75], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[52:55], a[76:79], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v202 offset:17472                   
+	ds_read_b32 v188, v206 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[56:59], a[96:99], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[60:63], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v202 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[56:59], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[60:63], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v202 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[64:67], a[96:99], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[68:71], a[100:103], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v202 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[64:67], a[104:107], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[68:71], a[108:111], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v202 offset:21696                 
+	ds_read_b32 v189, v206 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[72:75], a[128:131], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[76:79], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v202 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[72:75], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[76:79], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v202 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[80:83], a[128:131], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[84:87], a[132:135], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v202 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[80:83], a[136:139], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[84:87], a[140:143], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v202 offset:25920                 
+	ds_read_b32 v190, v206 offset:1536                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[88:91], a[160:163], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[92:95], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[88:91], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[92:95], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[96:99], a[160:163], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[100:103], a[164:167], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[96:99], a[168:171], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[100:103], a[172:175], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[120:123], v[104:107], a[192:195], v191, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[120:123], v[108:111], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[124:127], v[104:107], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[124:127], v[108:111], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[128:131], v[112:115], a[192:195], v191, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[128:131], v[116:119], a[196:199], v191, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[132:135], v[112:115], a[200:203], v191, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[132:135], v[116:119], a[204:207], v191, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[8:11], a[16:19], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[12:15], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[8:11], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[12:15], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[16:19], a[16:19], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[20:23], a[20:23], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[16:19], a[24:27], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[20:23], a[28:31], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[24:27], a[48:51], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[28:31], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[24:27], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[28:31], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[32:35], a[48:51], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[36:39], a[52:55], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[32:35], a[56:59], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[36:39], a[60:63], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[40:43], a[80:83], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[44:47], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[40:43], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[44:47], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[48:51], a[80:83], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[52:55], a[84:87], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[48:51], a[88:91], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[52:55], a[92:95], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[56:59], a[112:115], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[60:63], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[56:59], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[60:63], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[64:67], a[112:115], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[68:71], a[116:119], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[64:67], a[120:123], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[68:71], a[124:127], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[72:75], a[144:147], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[76:79], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[72:75], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[76:79], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[80:83], a[144:147], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[84:87], a[148:151], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[80:83], a[152:155], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[84:87], a[156:159], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[88:91], a[176:179], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[92:95], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v203                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[88:91], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[92:95], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v203 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[96:99], a[176:179], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[100:103], a[180:183], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v203 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[96:99], a[184:187], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[100:103], a[188:191], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v203 offset:576                     
+	ds_read_b32 v184, v206 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[136:139], v[104:107], a[208:211], v192, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[136:139], v[108:111], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v203 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[140:143], v[104:107], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[140:143], v[108:111], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v203 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[112:115], a[208:211], v192, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[116:119], a[212:215], v192, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v203 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[148:151], v[112:115], a[216:219], v192, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[148:151], v[116:119], a[220:223], v192, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v203 offset:4800                    
+	ds_read_b32 v185, v206 offset:2304                         
+	s_cbranch_scc0 label_0D3D                                  
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v203 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v203 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v203 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v203 offset:9024                    
+	ds_read_b32 v186, v206 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v203 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v203 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v203 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v203 offset:13248                   
+	ds_read_b32 v187, v206 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[40:43], a[64:67], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[44:47], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[72:75], v203 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[40:43], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[44:47], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[80:83], v203 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[48:51], a[64:67], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[52:55], a[68:71], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[76:79], v203 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[48:51], a[72:75], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[52:55], a[76:79], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v203 offset:17472                   
+	ds_read_b32 v188, v206 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[56:59], a[96:99], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[60:63], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b128 v[88:91], v203 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[56:59], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[60:63], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v203 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[64:67], a[96:99], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[68:71], a[100:103], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v203 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[64:67], a[104:107], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[68:71], a[108:111], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v203 offset:21696                 
+	ds_read_b32 v189, v206 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v203 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v203 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v203 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v203 offset:25920                 
+	ds_read_b32 v190, v206 offset:3584                         
+	s_barrier                                                  
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[152:155], v[88:91], a[160:163], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v204, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[152:155], v[92:95], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[88:91], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[92:95], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[160:163], v[96:99], a[160:163], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v205, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[160:163], v[100:103], a[164:167], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[164:167], v[96:99], a[168:171], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[164:167], v[100:103], a[172:175], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[104:107], a[192:195], v193, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[108:111], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[104:107], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[108:111], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[112:115], a[192:195], v193, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[116:119], a[196:199], v193, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[112:115], a[200:203], v193, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[116:119], a[204:207], v193, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[8:11], a[16:19], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[12:15], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[8:11], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[12:15], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[16:19], a[16:19], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v198, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[20:23], a[20:23], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[16:19], a[24:27], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[20:23], a[28:31], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[24:27], a[48:51], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v199, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[28:31], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[24:27], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[28:31], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[32:35], a[48:51], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v200, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[36:39], a[52:55], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[32:35], a[56:59], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[36:39], a[60:63], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[40:43], a[80:83], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v201, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[44:47], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[40:43], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[44:47], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[48:51], a[80:83], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[152:155], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[52:55], a[84:87], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[48:51], a[88:91], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[52:55], a[92:95], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[56:59], a[112:115], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[156:159], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[60:63], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[56:59], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[60:63], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[64:67], a[112:115], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[160:163], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[68:71], a[116:119], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[64:67], a[120:123], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[68:71], a[124:127], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v211, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[168:171], v[88:91], a[176:179], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[168:171], v[92:95], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v202                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[88:91], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[92:95], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v202 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[176:179], v[96:99], a[176:179], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[176:179], v[100:103], a[180:183], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v202 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[180:183], v[96:99], a[184:187], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[180:183], v[100:103], a[188:191], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v202 offset:576                     
+	ds_read_b32 v184, v206                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[104:107], a[208:211], v194, v190 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[108:111], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v202 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[104:107], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[108:111], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v202 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[112:115], a[208:211], v194, v190 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[116:119], a[212:215], v194, v190 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v202 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[112:115], a[216:219], v194, v190 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[116:119], a[220:223], v194, v190 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v202 offset:4800                    
+	ds_read_b32 v185, v206 offset:256                          
+	s_cbranch_scc0 label_0D3D                                  
+	s_branch label_0878                                        
+	
+label_0D3D:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_barrier                                                  
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_i32_i24_e32 v5, 0x80, v5                             
+	v_add_u32_e32 v4, v4, v5                                   
+	s_mul_i32 s62, s46, 0x7000                                 
+	s_add_i32 s62, s62, 0                                      
+	v_add_i32 v4, v4, s62                                      
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19]                                 
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:64                       
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2048                     
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:2112                     
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4096                     
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:4160                     
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6144                     
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:6208                     
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8192                     
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:8256                     
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10240                    
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:10304                    
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12288                    
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:12352                    
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14336                    
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:14400                    
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16384                    
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:16448                    
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18432                    
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:18496                    
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20480                    
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:20544                    
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22528                    
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:22592                    
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:24576                    
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:24640                    
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:26624                    
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	ds_write_b128 v4, v[16:19] offset:26688                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mul_i32_i24_e64 v4, v0, 16                               
+	v_add_i32 v4, v4, s62                                      
+	ds_read_b128 v[16:19], v4                                  
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v213, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:1024                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v214, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:2048                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v215, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:3072                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v216, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:4096                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v217, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:5120                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v218, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:6144                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v219, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:7168                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v220, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:8192                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:9216                      
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v222, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:10240                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v223, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:11264                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v224, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:12288                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v225, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:13312                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:14336                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:15360                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v228, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:16384                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v229, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:17408                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v230, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:18432                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v231, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:19456                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:20480                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v233, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:21504                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:22528                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v235, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:23552                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v236, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:24576                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v237, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:25600                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v238, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:26624                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v239, s[4:7], 0 offen       
+	ds_read_b128 v[16:19], v4 offset:27648                     
+	s_waitcnt lgkmcnt(0)                                       
+	buffer_store_dwordx4 v[16:19], v240, s[4:7], 0 offen       
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_224x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2473,7 +2473,7 @@ label_1450:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2920,14 +2920,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA.s
@@ -1,0 +1,2938 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0xff                                   
+	s_lshr_b32 s62, s51, 8                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_003A:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003F                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_003A                                        
+	
+label_003F:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0045                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0065                                        
+	
+label_0045:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0065:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x100                                  
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v220, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v220, v5, v220                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v220, v6, v220                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v220, v4, v220                               
+	v_add_u32_e32 v220, 0x2000, v220                           
+	v_add_u32_e32 v221, 0x8400, v220                           
+	v_add_u32_e32 v222, 0x8400, v221                           
+	v_add_u32_e32 v223, 0x8400, v222                           
+	s_mul_i32 s62, s48, 0x100                                  
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v224, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v224, s63, v224                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v225, s63, v224                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v226, 2, v0                              
+	v_add_u32_e32 v226, 0, v226                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v227, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v227, s62, v227                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v228, s62, v227                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v229, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v229, s63, v229                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dword v208, v229, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[152:155], v227, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[156:159], v228, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[160:163], v227, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[164:167], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v229, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[168:171], v227, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[172:175], v228, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v229, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(41)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v220                                 
+	ds_read_b128 v[16:19], v220 offset:64                      
+	ds_read_b128 v[12:15], v220 offset:512                     
+	ds_read_b128 v[20:23], v220 offset:576                     
+	ds_read_b32 v200, v226                                     
+	ds_read_b128 v[24:27], v220 offset:4224                    
+	ds_read_b128 v[32:35], v220 offset:4288                    
+	ds_read_b128 v[28:31], v220 offset:4736                    
+	ds_read_b128 v[36:39], v220 offset:4800                    
+	ds_read_b32 v201, v226 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x100                                  
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x100                                    
+	s_cselect_b32 s62, s62, 0x100                              
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v230, s36, v5                                 
+	v_add_u32_e32 v230, s62, v230                              
+	v_add_u32_e32 v230, v4, v230                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_09AD                                  
+	
+label_031A:
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ce00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1de80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ef00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ff80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v220 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[184:187], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[188:191], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:1792                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[120:123], a[112:115], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[124:127], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[120:123], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[124:127], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[128:131], a[112:115], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[132:135], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[128:131], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v221 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[132:135], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:2304                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v221 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v221 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v221 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:3840                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v222                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v222 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v222 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v222 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[120:123], a[112:115], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v222 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[124:127], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[120:123], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v222 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[124:127], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[128:131], a[112:115], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v222 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[132:135], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[128:131], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v222 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[132:135], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:4352                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v222 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v222 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v222 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v222 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v222 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v222 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v222 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v222 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v222 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v222 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v222 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v222 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v222 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v222 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v222 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v222 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v222 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v222 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v222 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v222 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:5632                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v222 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v222 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v222 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v222 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:5888                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v223                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v223 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v223 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v223 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[120:123], a[112:115], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v223 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[124:127], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[120:123], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v223 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[124:127], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[128:131], a[112:115], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v223 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[132:135], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[128:131], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v223 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[132:135], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:6400                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[8:11], a[0:3], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v223 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[12:15], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[188:191], v[8:11], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v223 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[188:191], v[12:15], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[192:195], v[16:19], a[0:3], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v223 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[192:195], v[20:23], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[196:199], v[16:19], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v223 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[196:199], v[20:23], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[24:27], a[16:19], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v223 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[28:31], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[188:191], v[24:27], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v223 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[188:191], v[28:31], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[192:195], v[32:35], a[16:19], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v223 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[192:195], v[36:39], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[196:199], v[32:35], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v223 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[196:199], v[36:39], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[40:43], a[32:35], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v223 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[44:47], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[40:43], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v223 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[44:47], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[48:51], a[32:35], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v223 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[52:55], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[48:51], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v223 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[52:55], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[184:187], v[56:59], a[48:51], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v223 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[184:187], v[60:63], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[56:59], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v223 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[60:63], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[192:195], v[64:67], a[48:51], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v223 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[192:195], v[68:71], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[196:199], v[64:67], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v223 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[196:199], v[68:71], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[72:75], a[64:67], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v223 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[76:79], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[188:191], v[72:75], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v223 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[188:191], v[76:79], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[80:83], a[64:67], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v223 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[84:87], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[196:199], v[80:83], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v223 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[196:199], v[84:87], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:7680                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[88:91], a[80:83], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v223 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[92:95], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[88:91], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v223 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[92:95], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[96:99], a[80:83], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v223 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[100:103], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[96:99], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v223 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[100:103], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:7936                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[184:187], v[104:107], a[96:99], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[184:187], v[108:111], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[188:191], v[104:107], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[188:191], v[108:111], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[112:115], a[96:99], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[116:119], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[112:115], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[116:119], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[120:123], a[112:115], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[124:127], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[120:123], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[124:127], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[128:131], a[112:115], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[132:135], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[128:131], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v220 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[132:135], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:256                          
+	s_cbranch_scc0 label_1040                                  
+	s_branch label_031A                                        
+	
+label_09AD:
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:9024                    
+	ds_read_b32 v202, v226 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	ds_read_b32 v203, v226 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:17472                   
+	ds_read_b32 v204, v226 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ce00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1de80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:21696                 
+	ds_read_b32 v205, v226 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ef00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ff80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v220 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v220 offset:25920                 
+	ds_read_b32 v206, v226 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[184:187], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v220 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[188:191], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	ds_read_b32 v207, v226 offset:1792                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:576                     
+	ds_read_b32 v200, v226 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[120:123], a[112:115], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[124:127], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[120:123], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[124:127], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[128:131], a[112:115], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[132:135], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[128:131], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[132:135], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v221 offset:4800                    
+	ds_read_b32 v201, v226 offset:2304                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:9024                    
+	ds_read_b32 v202, v226 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	ds_read_b32 v203, v226 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:17472                   
+	ds_read_b32 v204, v226 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:21696                 
+	ds_read_b32 v205, v226 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v221 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v221 offset:25920                 
+	ds_read_b32 v206, v226 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v221 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	ds_read_b32 v207, v226 offset:3840                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v222                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v222 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v222 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v222 offset:576                     
+	ds_read_b32 v200, v226 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[120:123], a[112:115], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[124:127], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v222 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[120:123], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[124:127], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v222 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[128:131], a[112:115], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[132:135], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v222 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[128:131], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[132:135], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v222 offset:4800                    
+	ds_read_b32 v201, v226 offset:4352                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v222 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v222 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v222 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v222 offset:9024                    
+	ds_read_b32 v202, v226 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v222 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v222 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v222 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v222 offset:13248                   
+	ds_read_b32 v203, v226 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v222 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v222 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v222 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v222 offset:17472                   
+	ds_read_b32 v204, v226 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v222 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v222 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v222 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v222 offset:21696                 
+	ds_read_b32 v205, v226 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v222 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v222 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v222 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v222 offset:25920                 
+	ds_read_b32 v206, v226 offset:5632                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v222 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v222 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v222 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v222 offset:30144                 
+	ds_read_b32 v207, v226 offset:5888                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v223                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v223 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v223 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v223 offset:576                     
+	ds_read_b32 v200, v226 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[120:123], a[112:115], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[124:127], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v223 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[120:123], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[124:127], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v223 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[128:131], a[112:115], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[132:135], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v223 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[128:131], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[132:135], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v223 offset:4800                    
+	ds_read_b32 v201, v226 offset:6400                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[8:11], a[0:3], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[12:15], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v223 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[188:191], v[8:11], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[188:191], v[12:15], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v223 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[192:195], v[16:19], a[0:3], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[192:195], v[20:23], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v223 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[196:199], v[16:19], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[196:199], v[20:23], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v223 offset:9024                    
+	ds_read_b32 v202, v226 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[24:27], a[16:19], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[28:31], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v223 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[188:191], v[24:27], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[188:191], v[28:31], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v223 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[192:195], v[32:35], a[16:19], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[192:195], v[36:39], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v223 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[196:199], v[32:35], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[196:199], v[36:39], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v223 offset:13248                   
+	ds_read_b32 v203, v226 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[40:43], a[32:35], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[44:47], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v223 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[40:43], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[44:47], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v223 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[48:51], a[32:35], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[52:55], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v223 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[48:51], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[52:55], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v223 offset:17472                   
+	ds_read_b32 v204, v226 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[184:187], v[56:59], a[48:51], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[184:187], v[60:63], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v223 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[56:59], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[60:63], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v223 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[192:195], v[64:67], a[48:51], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[192:195], v[68:71], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v223 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[196:199], v[64:67], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[196:199], v[68:71], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v223 offset:21696                 
+	ds_read_b32 v205, v226 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[72:75], a[64:67], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[76:79], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v223 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[188:191], v[72:75], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[188:191], v[76:79], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v223 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[80:83], a[64:67], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[84:87], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v223 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[196:199], v[80:83], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[196:199], v[84:87], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v223 offset:25920                 
+	ds_read_b32 v206, v226 offset:7680                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[88:91], a[80:83], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[92:95], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v223 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[88:91], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[92:95], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v223 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[96:99], a[80:83], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[100:103], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v223 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[96:99], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[100:103], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v223 offset:30144                 
+	ds_read_b32 v207, v226 offset:7936                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[184:187], v[104:107], a[96:99], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[184:187], v[108:111], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[188:191], v[104:107], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[188:191], v[108:111], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[112:115], a[96:99], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[116:119], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[112:115], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[116:119], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:576                     
+	ds_read_b32 v200, v226                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[120:123], a[112:115], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v229, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[124:127], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[120:123], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[124:127], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[128:131], a[112:115], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[132:135], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[128:131], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[132:135], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v220 offset:4800                    
+	ds_read_b32 v201, v226 offset:256                          
+	s_cbranch_scc0 label_1040                                  
+	s_branch label_09AD                                        
+	
+label_1040:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_124B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v234, 0, v230                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	s_branch label_1450                                        
+	
+label_124B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1450                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v234, 0, v230                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	
+label_1450:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB.s
@@ -1,0 +1,2938 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0xff                                   
+	s_lshr_b32 s62, s51, 8                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_003A:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003F                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_003A                                        
+	
+label_003F:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0045                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0065                                        
+	
+label_0045:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0065:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x100                                  
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x2000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v220, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v220, v5, v220                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v220, v6, v220                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v220, v4, v220                               
+	v_add_u32_e32 v220, 0x2000, v220                           
+	v_add_u32_e32 v221, 0x8400, v220                           
+	v_add_u32_e32 v222, 0x8400, v221                           
+	v_add_u32_e32 v223, 0x8400, v222                           
+	s_mul_i32 s62, s48, 0x100                                  
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v224, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v224, s63, v224                              
+	s_mul_i32 s63, 0x80, s39                                   
+	v_add_u32_e32 v225, s63, v224                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v226, 2, v0                              
+	v_add_u32_e32 v226, 0, v226                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v227, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v227, s62, v227                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v228, s62, v227                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v229, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v229, s63, v229                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dword v208, v229, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[152:155], v227, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[156:159], v228, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[160:163], v227, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[164:167], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v229, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[168:171], v227, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[172:175], v228, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v229, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(41)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v220                                 
+	ds_read_b128 v[16:19], v220 offset:64                      
+	ds_read_b128 v[12:15], v220 offset:512                     
+	ds_read_b128 v[20:23], v220 offset:576                     
+	ds_read_b32 v200, v226                                     
+	ds_read_b128 v[24:27], v220 offset:4224                    
+	ds_read_b128 v[32:35], v220 offset:4288                    
+	ds_read_b128 v[28:31], v220 offset:4736                    
+	ds_read_b128 v[36:39], v220 offset:4800                    
+	ds_read_b32 v201, v226 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x100                                  
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x100                                    
+	s_cselect_b32 s62, s62, 0x100                              
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v230, s36, v5                                 
+	v_add_u32_e32 v230, s62, v230                              
+	v_add_u32_e32 v230, v4, v230                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_09AD                                  
+	
+label_031A:
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ce00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1de80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ef00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ff80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v220 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[184:187], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[188:191], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:1792                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[120:123], a[112:115], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[124:127], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[120:123], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[124:127], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[128:131], a[112:115], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[132:135], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[128:131], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v221 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[132:135], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:2304                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v221 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v221 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v221 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:3840                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v222                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v222 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v222 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v222 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[120:123], a[112:115], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v222 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[124:127], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[120:123], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v222 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[124:127], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[128:131], a[112:115], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v222 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[132:135], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[128:131], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v222 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[132:135], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:4352                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v222 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v222 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v222 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v222 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v222 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v222 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v222 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v222 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v222 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v222 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v222 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v222 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v222 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v222 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v222 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v222 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v222 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v222 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v222 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v222 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:5632                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v222 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v222 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v222 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v222 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:5888                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v223                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v223 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v223 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v223 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[120:123], a[112:115], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v223 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[124:127], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[120:123], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v223 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[124:127], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[128:131], a[112:115], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v223 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[132:135], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[128:131], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v223 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[132:135], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:6400                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[8:11], a[0:3], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v223 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[12:15], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[188:191], v[8:11], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v223 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[188:191], v[12:15], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[192:195], v[16:19], a[0:3], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v223 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[192:195], v[20:23], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[196:199], v[16:19], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v223 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[196:199], v[20:23], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v226 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[24:27], a[16:19], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v223 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[28:31], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[188:191], v[24:27], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v223 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[188:191], v[28:31], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[192:195], v[32:35], a[16:19], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v223 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[192:195], v[36:39], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[196:199], v[32:35], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v223 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[196:199], v[36:39], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v226 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[40:43], a[32:35], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v223 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[44:47], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[40:43], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v223 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[44:47], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[48:51], a[32:35], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v223 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[52:55], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[48:51], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v223 offset:17472                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[52:55], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v226 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[184:187], v[56:59], a[48:51], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v223 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[184:187], v[60:63], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[56:59], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v223 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[60:63], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[192:195], v[64:67], a[48:51], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v223 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[192:195], v[68:71], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[196:199], v[64:67], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v223 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[196:199], v[68:71], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v226 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[72:75], a[64:67], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v223 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[76:79], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[188:191], v[72:75], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v223 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[188:191], v[76:79], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[80:83], a[64:67], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v223 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[84:87], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[196:199], v[80:83], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[116:119], v223 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[196:199], v[84:87], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b32 v206, v226 offset:7680                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[88:91], a[80:83], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[120:123], v223 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[92:95], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[88:91], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[128:131], v223 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[92:95], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[96:99], a[80:83], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[124:127], v223 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[100:103], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[96:99], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[132:135], v223 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[100:103], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b32 v207, v226 offset:7936                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[184:187], v[104:107], a[96:99], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[184:187], v[108:111], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[188:191], v[104:107], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[188:191], v[108:111], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[112:115], a[96:99], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[116:119], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[112:115], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[116:119], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v226                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[120:123], a[112:115], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[124:127], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[120:123], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[124:127], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[128:131], a[112:115], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[132:135], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[128:131], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v220 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[132:135], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v201, v226 offset:256                          
+	s_cbranch_scc0 label_1040                                  
+	s_branch label_031A                                        
+	
+label_09AD:
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1800, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1c00, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:9024                    
+	ds_read_b32 v202, v226 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x18c00, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x19c80, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	ds_read_b32 v203, v226 offset:768                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ad00, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1bd80, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:17472                   
+	ds_read_b32 v204, v226 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[136:139], v[56:59], a[48:51], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ce00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[136:139], v[60:63], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[56:59], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[60:63], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[144:147], v[64:67], a[48:51], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1de80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[144:147], v[68:71], a[52:55], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[148:151], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[148:151], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:21696                 
+	ds_read_b32 v205, v226 offset:1280                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[72:75], a[64:67], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ef00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[76:79], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[72:75], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[76:79], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[80:83], a[64:67], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1ff80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[84:87], a[68:71], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v220 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[80:83], a[72:75], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[84:87], a[76:79], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v220 offset:25920                 
+	ds_read_b32 v206, v226 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[88:91], a[80:83], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[184:187], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[92:95], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v220 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[88:91], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[92:95], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[96:99], a[80:83], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[188:191], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[100:103], a[84:87], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[96:99], a[88:91], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[100:103], a[92:95], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	ds_read_b32 v207, v226 offset:1792                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[104:107], a[96:99], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[108:111], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[104:107], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[108:111], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[112:115], a[96:99], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[116:119], a[100:103], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[112:115], a[104:107], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[116:119], a[108:111], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:576                     
+	ds_read_b32 v200, v226 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[120:123], a[112:115], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[124:127], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[120:123], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[124:127], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[128:131], a[112:115], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[132:135], a[116:119], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[128:131], a[120:123], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[132:135], a[124:127], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v221 offset:4800                    
+	ds_read_b32 v201, v226 offset:2304                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[8:11], a[0:3], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[12:15], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[8:11], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[12:15], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[16:19], a[0:3], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[20:23], a[4:7], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[16:19], a[8:11], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[20:23], a[12:15], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:9024                    
+	ds_read_b32 v202, v226 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[24:27], a[16:19], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[28:31], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[24:27], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[28:31], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[32:35], a[16:19], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[36:39], a[20:23], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[32:35], a[24:27], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[36:39], a[28:31], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	ds_read_b32 v203, v226 offset:2816                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:17472                   
+	ds_read_b32 v204, v226 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:21696                 
+	ds_read_b32 v205, v226 offset:3328                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[152:155], v[72:75], a[64:67], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[152:155], v[76:79], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[156:159], v[72:75], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[156:159], v[76:79], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[80:83], a[64:67], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[84:87], a[68:71], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v221 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[164:167], v[80:83], a[72:75], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[164:167], v[84:87], a[76:79], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v221 offset:25920                 
+	ds_read_b32 v206, v226 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v221 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	ds_read_b32 v207, v226 offset:3840                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[104:107], a[96:99], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[108:111], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v222                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[104:107], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[108:111], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v222 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[112:115], a[96:99], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[116:119], a[100:103], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v222 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[112:115], a[104:107], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[116:119], a[108:111], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v222 offset:576                     
+	ds_read_b32 v200, v226 offset:4096                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[120:123], a[112:115], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[124:127], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v222 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[120:123], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[124:127], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v222 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[128:131], a[112:115], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[132:135], a[116:119], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v222 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[128:131], a[120:123], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[132:135], a[124:127], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v222 offset:4800                    
+	ds_read_b32 v201, v226 offset:4352                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v222 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[172:175], v[8:11], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[172:175], v[12:15], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v222 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[176:179], v[16:19], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[176:179], v[20:23], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v222 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[180:183], v[16:19], a[8:11], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[180:183], v[20:23], a[12:15], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v222 offset:9024                    
+	ds_read_b32 v202, v226 offset:4608                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v222 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[24:27], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[28:31], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v222 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[32:35], a[16:19], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[36:39], a[20:23], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v222 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[32:35], a[24:27], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[36:39], a[28:31], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v222 offset:13248                   
+	ds_read_b32 v203, v226 offset:4864                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[168:171], v[40:43], a[32:35], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[168:171], v[44:47], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v222 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[40:43], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[44:47], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v222 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[176:179], v[48:51], a[32:35], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[176:179], v[52:55], a[36:39], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v222 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[180:183], v[48:51], a[40:43], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[180:183], v[52:55], a[44:47], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v222 offset:17472                   
+	ds_read_b32 v204, v226 offset:5120                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[168:171], v[56:59], a[48:51], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s64                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[168:171], v[60:63], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v222 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[56:59], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[60:63], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v222 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[176:179], v[64:67], a[48:51], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s64                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[176:179], v[68:71], a[52:55], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v222 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[180:183], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[180:183], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v222 offset:21696                 
+	ds_read_b32 v205, v226 offset:5376                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s64                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v222 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v222 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s64                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v222 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v222 offset:25920                 
+	ds_read_b32 v206, v226 offset:5632                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[168:171], v[88:91], a[80:83], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[152:155], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[168:171], v[92:95], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v222 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[172:175], v[88:91], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[172:175], v[92:95], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v222 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[96:99], a[80:83], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[156:159], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[100:103], a[84:87], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v222 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[180:183], v[96:99], a[88:91], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[180:183], v[100:103], a[92:95], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v222 offset:30144                 
+	ds_read_b32 v207, v226 offset:5888                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[104:107], a[96:99], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[108:111], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v223                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[104:107], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[108:111], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v223 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[112:115], a[96:99], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[116:119], a[100:103], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v223 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[112:115], a[104:107], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[116:119], a[108:111], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v223 offset:576                     
+	ds_read_b32 v200, v226 offset:6144                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[120:123], a[112:115], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[124:127], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v223 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[120:123], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[124:127], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v223 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[128:131], a[112:115], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[132:135], a[116:119], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v223 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[128:131], a[120:123], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[132:135], a[124:127], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v223 offset:4800                    
+	ds_read_b32 v201, v226 offset:6400                         
+	s_cbranch_scc0 label_1040                                  
+	s_waitcnt vmcnt(30) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[8:11], a[0:3], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1000, s65                                  
+	buffer_load_dword v224, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[12:15], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v223 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[188:191], v[8:11], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[188:191], v[12:15], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v223 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[192:195], v[16:19], a[0:3], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1400, s65                                  
+	buffer_load_dword v225, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[192:195], v[20:23], a[4:7], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v223 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[196:199], v[16:19], a[8:11], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[196:199], v[20:23], a[12:15], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v223 offset:9024                    
+	ds_read_b32 v202, v226 offset:6656                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[24:27], a[16:19], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x10800, s64                                 
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[28:31], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v223 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[188:191], v[24:27], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[188:191], v[28:31], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v223 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[192:195], v[32:35], a[16:19], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x11880, s64                                 
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[192:195], v[36:39], a[20:23], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v223 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[196:199], v[32:35], a[24:27], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[196:199], v[36:39], a[28:31], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v223 offset:13248                   
+	ds_read_b32 v203, v226 offset:6912                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[40:43], a[32:35], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x12900, s64                                 
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[44:47], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v223 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[40:43], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[44:47], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v223 offset:16960                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[48:51], a[32:35], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x13980, s64                                 
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[52:55], a[36:39], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v223 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[48:51], a[40:43], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[52:55], a[44:47], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v223 offset:17472                   
+	ds_read_b32 v204, v226 offset:7168                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[184:187], v[56:59], a[48:51], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x14a00, s64                                 
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[184:187], v[60:63], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v223 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[56:59], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[60:63], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v223 offset:21184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[192:195], v[64:67], a[48:51], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x15a80, s64                                 
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[192:195], v[68:71], a[52:55], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v223 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[196:199], v[64:67], a[56:59], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[196:199], v[68:71], a[60:63], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v223 offset:21696                 
+	ds_read_b32 v205, v226 offset:7424                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[184:187], v[72:75], a[64:67], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x16b00, s64                                 
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[184:187], v[76:79], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v223 offset:25344                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[188:191], v[72:75], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[188:191], v[76:79], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v223 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[80:83], a[64:67], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x17b80, s64                                 
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[84:87], a[68:71], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[108:111], v223 offset:25856                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[196:199], v[80:83], a[72:75], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[196:199], v[84:87], a[76:79], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	ds_read_b128 v[116:119], v223 offset:25920                 
+	ds_read_b32 v206, v226 offset:7680                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[88:91], a[80:83], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	buffer_load_dwordx4 v[168:171], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[92:95], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	ds_read_b128 v[120:123], v223 offset:29568                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[88:91], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[92:95], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[128:131], v223 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[96:99], a[80:83], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[172:175], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[100:103], a[84:87], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[124:127], v223 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[96:99], a[88:91], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[100:103], a[92:95], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[132:135], v223 offset:30144                 
+	ds_read_b32 v207, v226 offset:7936                         
+	s_waitcnt vmcnt(38) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[184:187], v[104:107], a[96:99], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[184:187], v[108:111], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[188:191], v[104:107], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[188:191], v[108:111], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[192:195], v[112:115], a[96:99], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[192:195], v[116:119], a[100:103], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[112:115], a[104:107], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[116:119], a[108:111], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:576                     
+	ds_read_b32 v200, v226                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[120:123], a[112:115], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v229, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[124:127], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[120:123], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[124:127], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[128:131], a[112:115], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[132:135], a[116:119], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[128:131], a[120:123], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[132:135], a[124:127], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v220 offset:4800                    
+	ds_read_b32 v201, v226 offset:256                          
+	s_cbranch_scc0 label_1040                                  
+	s_branch label_09AD                                        
+	
+label_1040:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_124B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v234, 0, v230                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	s_branch label_1450                                        
+	
+label_124B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1450                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v234, 0, v230                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v234, s[4:7], 0 offen       
+	v_add_u32_e32 v234, s62, v234                              
+	
+label_1450:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_256x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2697,7 +2697,7 @@ label_0ECC:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -3144,14 +3144,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA.s
@@ -1,0 +1,3162 @@
+// Auto-generated from FP4_GEMM_1TG_4W_MT256x256x256_B_Shuffle_Epilogue.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s32, s[0:1], 0x40                             
+	s_load_dword s33, s[0:1], 0x50                             
+	s_load_dword s34, s[0:1], 0x80                             
+	s_load_dword s35, s[0:1], 0xa0                             
+	s_load_dword s36, s[0:1], 0xc0                             
+	s_load_dword s39, s[0:1], 0xe0                             
+	s_load_dword s40, s[0:1], 0xf0                             
+	s_load_dword s41, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s37, s[0:1], 0x130                            
+	s_load_dword s38, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s53, s2                                          
+	s_mov_b32 s54, s3                                          
+	v_readfirstlane_b32 s42, v3                                
+	s_mov_b32 s68, 0x80                                        
+	s_mov_b32 s69, 0x800                                       
+	s_mov_b32 s70, 0x100                                       
+	s_mov_b32 s71, 0x100                                       
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s46, s40, 0xff                                   
+	s_lshr_b32 s46, s46, 8                                     
+	s_mul_i32 s48, s46, s54                                    
+	s_add_i32 s48, s48, s53                                    
+	s_lshr_b32 s49, s46, 5                                     
+	s_lshl_b32 s49, s49, 5                                     
+	s_sub_i32 s50, s46, s49                                    
+	s_add_u32 s51, s39, 0xff                                   
+	s_lshr_b32 s51, s51, 8                                     
+	s_mul_i32 s52, s49, s51                                    
+	s_cmp_lt_i32 s48, s52                                      
+	s_cbranch_scc0 label_006B                                  
+	s_lshr_b32 s46, s48, 5                                     
+	v_cvt_f32_u32_e32 v4, s51                                  
+	s_sub_i32 s47, 0, s51                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s47, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s46, v4                                   
+	v_mul_lo_u32 v5, v4, s51                                   
+	v_sub_u32_e32 v7, s46, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s51, v7                              
+	v_subrev_u32_e32 v5, s51, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s51, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s47, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s54, s51, s47                                    
+	s_sub_i32 s54, s46, s54                                    
+	s_and_b32 s46, s48, 31                                     
+	s_lshl_b32 s53, s47, 5                                     
+	s_add_i32 s53, s53, s46                                    
+	s_branch label_008D                                        
+	
+label_006B:
+	s_sub_i32 s46, s48, s52                                    
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s54, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s54, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s46, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s46, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s54, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s47, s50, s54                                    
+	s_sub_i32 s53, s46, s47                                    
+	s_add_i32 s53, s49, s53                                    
+	
+label_008D:
+	s_lshr_b32 s35, s35, 1                                     
+	s_mov_b32 s15, 0x20000                                     
+	s_and_b32 s13, s13, 0xffff                                 
+	s_or_b32 s13, s13, 0x40000                                 
+	s_mul_i32 s14, s35, s39                                    
+	s_mov_b32 s23, 0x20000                                     
+	s_and_b32 s21, s21, 0xffff                                 
+	s_or_b32 s21, s21, 0x40000                                 
+	s_add_u32 s46, s39, 31                                     
+	s_lshr_b32 s46, s46, 5                                     
+	s_lshl_b32 s46, s46, 5                                     
+	s_mul_i32 s22, s46, s37                                    
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s35, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v212, v4                               
+	s_lshr_b32 s46, s42, 1                                     
+	s_lshl_b32 s46, s46, 3                                     
+	s_and_b32 s47, s42, 1                                      
+	s_lshl_b32 s47, s47, 1                                     
+	s_add_u32 s46, s46, s47                                    
+	s_lshl_b32 s47, s54, 8                                     
+	s_add_u32 s46, s46, s47                                    
+	s_mul_i32 s46, s35, s46                                    
+	v_add_u32_e32 v212, s46, v212                              
+	s_lshl_b32 s46, s35, 5                                     
+	v_add_u32_e32 v213, s46, v212                              
+	v_add_u32_e32 v214, s46, v213                              
+	v_add_u32_e32 v215, s46, v214                              
+	v_add_u32_e32 v216, s46, v215                              
+	v_add_u32_e32 v217, s46, v216                              
+	v_add_u32_e32 v218, s46, v217                              
+	v_add_u32_e32 v219, s46, v218                              
+	s_mul_i32 s76, 0x420, s42                                  
+	s_add_u32 s76, 0x1000, s76                                 
+	s_lshl_b32 s46, s54, 8                                     
+	s_lshl_b32 s47, s42, 5                                     
+	s_add_i32 s47, s47, s46                                    
+	s_mul_i32 s47, s47, s37                                    
+	v_lshlrev_b32_e32 v222, 2, v0                              
+	v_add_u32_e32 v222, s47, v222                              
+	s_lshl_b32 s47, s37, 7                                     
+	v_add_u32_e32 v223, s47, v222                              
+	s_lshl_b32 s77, s42, 8                                     
+	s_add_i32 s77, s77, 0                                      
+	s_mov_b32 s33, s32                                         
+	s_mov_b32 s43, 0                                           
+	s_mov_b32 s44, s41                                         
+	s_add_u32 m0, 0, s76                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x1080, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0x2100, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x3180, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0, s77                                       
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 m0, 0x4200, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x5280, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	s_add_u32 m0, 0x6300, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 m0, 0x7380, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 m0, 0x400, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	s_add_u32 s45, 0x100, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	s_lshr_b32 s36, s36, 1                                     
+	s_mov_b32 s19, 0x20000                                     
+	s_and_b32 s17, s17, 0xffff                                 
+	s_or_b32 s17, s17, 0x40000                                 
+	s_mul_i32 s18, s36, s40                                    
+	s_mov_b32 s27, 0x20000                                     
+	s_and_b32 s25, s25, 0xffff                                 
+	s_or_b32 s25, s25, 0x40000                                 
+	s_mul_i32 s26, s38, s40                                    
+	s_lshl_b32 s46, s53, 8                                     
+	s_lshl_b32 s47, s42, 6                                     
+	s_add_i32 s46, s46, s47                                    
+	s_mul_i32 s46, s46, s36                                    
+	v_lshlrev_b32_e32 v225, 4, v0                              
+	v_add_u32_e32 v225, s46, v225                              
+	s_lshl_b32 s46, s36, 4                                     
+	v_add_u32_e32 v226, s46, v225                              
+	v_add_u32_e32 v227, s46, v226                              
+	v_add_u32_e32 v228, s46, v227                              
+	v_add_u32_e32 v229, 0x400, v225                            
+	v_add_u32_e32 v230, 0x400, v226                            
+	v_add_u32_e32 v231, 0x400, v227                            
+	v_add_u32_e32 v232, 0x400, v228                            
+	s_lshl_b32 s46, s53, 8                                     
+	s_lshl_b32 s47, s42, 6                                     
+	s_add_i32 s46, s46, s47                                    
+	s_mul_i32 s46, s46, s38                                    
+	v_lshlrev_b32_e32 v233, 2, v0                              
+	v_add_u32_e32 v233, s46, v233                              
+	s_mul_i32 s47, 32, s38                                     
+	v_add_u32_e32 v234, s47, v233                              
+	s_lshl_b32 s34, s34, 1                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_and_b32 s5, s5, 0xffff                                   
+	s_or_b32 s5, s5, 0x40000                                   
+	s_mul_i32 s6, s34, s39                                     
+	s_lshl_b32 s46, s53, 8                                     
+	s_lshl_b32 s47, s42, 6                                     
+	s_add_i32 s55, s46, s47                                    
+	s_lshl_b32 s46, s55, 1                                     
+	s_lshl_b32 s47, s54, 8                                     
+	s_mul_i32 s47, s47, s34                                    
+	s_add_u32 s46, s46, s47                                    
+	s_add_u32 s4, s4, s46                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_u32 s6, s6, s46                                      
+	v_and_b32_e64 v4, v0, 15                                   
+	v_mul_lo_u32 v4, v4, s34                                   
+	v_lshrrev_b32_e32 v5, 5, v0                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_lshrrev_b32_e32 v6, 4, v0                                
+	v_and_b32_e32 v6, 1, v6                                    
+	v_lshlrev_b32_e32 v6, 5, v6                                
+	v_add3_u32 v235, v4, v5, v6                                
+	s_lshl_b32 s47, s34, 4                                     
+	v_add_u32_e32 v236, s47, v235                              
+	v_add_u32_e32 v237, s47, v236                              
+	v_add_u32_e32 v238, s47, v237                              
+	v_add_u32_e32 v239, s47, v238                              
+	v_add_u32_e32 v240, s47, v239                              
+	v_add_u32_e32 v241, s47, v240                              
+	v_add_u32_e32 v242, s47, v241                              
+	v_add_u32_e32 v243, s47, v242                              
+	v_add_u32_e32 v244, s47, v243                              
+	v_add_u32_e32 v245, s47, v244                              
+	v_add_u32_e32 v246, s47, v245                              
+	v_add_u32_e32 v247, s47, v246                              
+	v_add_u32_e32 v248, s47, v247                              
+	v_add_u32_e32 v249, s47, v248                              
+	v_add_u32_e32 v250, s47, v249                              
+	buffer_load_dwordx4 v[136:139], v225, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[140:143], v226, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[160:163], v231, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dwordx4 v[164:167], v232, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dword v208, v233, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	buffer_load_dword v209, v234, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_add_u32 s45, 0x100, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v220, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v220, v5, v220                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v220, v6, v220                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v4, 0x1000, v4                               
+	v_add_u32_e32 v220, v4, v220                               
+	v_add_u32_e32 v221, 0x8400, v220                           
+	v_lshlrev_b32_e32 v224, 2, v0                              
+	v_add_u32_e32 v224, 0, v224                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v220                                 
+	ds_read_b128 v[40:43], v220 offset:64                      
+	s_add_u32 m0, 0x8400, s76                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	ds_read_b128 v[12:15], v220 offset:512                     
+	ds_read_b128 v[44:47], v220 offset:576                     
+	s_add_u32 m0, 0x9480, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	ds_read_b128 v[16:19], v220 offset:4224                    
+	ds_read_b128 v[48:51], v220 offset:4288                    
+	s_add_u32 m0, 0xa500, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	ds_read_b128 v[20:23], v220 offset:4736                    
+	ds_read_b128 v[52:55], v220 offset:4800                    
+	s_add_u32 m0, 0xb580, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	ds_read_b128 v[24:27], v220 offset:8448                    
+	ds_read_b128 v[56:59], v220 offset:8512                    
+	s_add_u32 m0, 0x800, s77                                   
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	ds_read_b128 v[28:31], v220 offset:8960                    
+	ds_read_b128 v[60:63], v220 offset:9024                    
+	s_add_u32 m0, 0xc600, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	ds_read_b128 v[32:35], v220 offset:12672                   
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	s_add_u32 m0, 0xd680, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	ds_read_b128 v[36:39], v220 offset:13184                   
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	s_add_u32 m0, 0xe700, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	ds_read_b32 v200, v224                                     
+	ds_read_b32 v201, v224 offset:256                          
+	s_add_u32 m0, 0xf780, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	ds_read_b32 v202, v224 offset:512                          
+	ds_read_b32 v203, v224 offset:768                          
+	s_add_u32 m0, 0xc00, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_accvgpr_write_b32 a240, 0                                
+	v_accvgpr_write_b32 a241, 0                                
+	v_accvgpr_write_b32 a242, 0                                
+	v_accvgpr_write_b32 a243, 0                                
+	v_accvgpr_write_b32 a244, 0                                
+	v_accvgpr_write_b32 a245, 0                                
+	v_accvgpr_write_b32 a246, 0                                
+	v_accvgpr_write_b32 a247, 0                                
+	v_accvgpr_write_b32 a248, 0                                
+	v_accvgpr_write_b32 a249, 0                                
+	v_accvgpr_write_b32 a250, 0                                
+	v_accvgpr_write_b32 a251, 0                                
+	v_accvgpr_write_b32 a252, 0                                
+	v_accvgpr_write_b32 a253, 0                                
+	v_accvgpr_write_b32 a254, 0                                
+	v_accvgpr_write_b32 a255, 0                                
+	s_mov_b32 s56, 0                                           
+	s_add_u32 s46, s43, 0x100                                  
+	s_cmp_lt_i32 s46, s44                                      
+	s_cbranch_scc0 label_0EA1                                  
+	s_cmp_lt_i32 s42, 2                                        
+	s_cbranch_scc0 label_094A                                  
+	
+label_03F3:
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[140:143], v[8:11], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[140:143], v[12:15], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[16:19], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[20:23], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[140:143], v[24:27], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[140:143], v[28:31], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[136:139], v[32:35], a[24:27], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[136:139], v[36:39], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[32:35], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[36:39], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[8:11], a[64:67], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[12:15], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[148:151], v[8:11], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[148:151], v[12:15], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[144:147], v[16:19], a[72:75], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[144:147], v[20:23], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[16:19], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[20:23], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[24:27], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[28:31], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[148:151], v[24:27], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[148:151], v[28:31], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[144:147], v[32:35], a[88:91], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[144:147], v[36:39], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[40:43], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[44:47], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[156:159], v[40:43], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v233, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[156:159], v[44:47], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[48:51], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[52:55], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[48:51], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[52:55], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[156:159], v[56:59], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[156:159], v[60:63], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[152:155], v[64:67], a[24:27], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[152:155], v[68:71], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[40:43], a[64:67], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[44:47], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[164:167], v[40:43], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[164:167], v[44:47], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[160:163], v[48:51], a[72:75], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[160:163], v[52:55], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[48:51], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[52:55], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[56:59], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[60:63], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[164:167], v[56:59], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[164:167], v[60:63], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[160:163], v[64:67], a[88:91], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[160:163], v[68:71], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[140:143], v[72:75], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s76                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[140:143], v[76:79], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[80:83], a[136:139], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[84:87], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[80:83], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[84:87], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[88:91], a[144:147], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[92:95], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[140:143], v[88:91], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[140:143], v[92:95], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[136:139], v[96:99], a[152:155], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[136:139], v[100:103], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[96:99], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[100:103], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[72:75], a[192:195], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[76:79], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[148:151], v[72:75], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s77                                       
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[148:151], v[76:79], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[144:147], v[80:83], a[200:203], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[144:147], v[84:87], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[148:151], v[80:83], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[148:151], v[84:87], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[88:91], a[208:211], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[92:95], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[148:151], v[88:91], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[148:151], v[92:95], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[144:147], v[96:99], a[216:219], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[144:147], v[100:103], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[148:151], v[96:99], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[148:151], v[100:103], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[104:107], a[128:131], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[108:111], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[156:159], v[104:107], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[156:159], v[108:111], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:2304                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[112:115], a[136:139], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[116:119], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:2560                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[112:115], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[116:119], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:2816                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[120:123], a[144:147], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[124:127], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[156:159], v[120:123], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[156:159], v[124:127], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[152:155], v[128:131], a[152:155], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[152:155], v[132:135], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 1                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[128:131], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[132:135], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[104:107], a[192:195], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[108:111], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[164:167], v[104:107], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[164:167], v[108:111], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[160:163], v[112:115], a[200:203], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[160:163], v[116:119], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[164:167], v[112:115], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[164:167], v[116:119], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[120:123], a[208:211], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[124:127], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[164:167], v[120:123], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[164:167], v[124:127], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[160:163], v[128:131], a[216:219], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[160:163], v[132:135], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[164:167], v[128:131], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[164:167], v[132:135], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[172:175], v[8:11], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[172:175], v[12:15], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[168:171], v[16:19], a[8:11], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[168:171], v[20:23], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[16:19], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[20:23], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v221 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[172:175], v[24:27], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[172:175], v[28:31], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[168:171], v[32:35], a[24:27], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[168:171], v[36:39], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[32:35], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[36:39], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v221 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[8:11], a[64:67], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[12:15], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[180:183], v[8:11], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[180:183], v[12:15], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[176:179], v[16:19], a[72:75], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[176:179], v[20:23], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v221 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[24:27], a[80:83], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[28:31], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[24:27], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[28:31], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[176:179], v[32:35], a[88:91], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[176:179], v[36:39], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[32:35], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[36:39], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[40:43], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[44:47], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[188:191], v[40:43], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v233, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[188:191], v[44:47], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:3328                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[184:187], v[48:51], a[8:11], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[184:187], v[52:55], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:3584                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[48:51], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[52:55], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:3840                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[56:59], a[16:19], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[60:63], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[188:191], v[56:59], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[188:191], v[60:63], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[184:187], v[64:67], a[24:27], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[184:187], v[68:71], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[40:43], a[64:67], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[44:47], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[196:199], v[40:43], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[196:199], v[44:47], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[192:195], v[48:51], a[72:75], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[192:195], v[52:55], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[48:51], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[52:55], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[56:59], a[80:83], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[60:63], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[56:59], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[60:63], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[192:195], v[64:67], a[88:91], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[192:195], v[68:71], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[72:75], a[128:131], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[76:79], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[172:175], v[72:75], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s76                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[172:175], v[76:79], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[168:171], v[80:83], a[136:139], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[168:171], v[84:87], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[172:175], v[80:83], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[172:175], v[84:87], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[88:91], a[144:147], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[92:95], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[172:175], v[88:91], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[172:175], v[92:95], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[168:171], v[96:99], a[152:155], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[168:171], v[100:103], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[96:99], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[100:103], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[176:179], v[72:75], a[192:195], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[176:179], v[76:79], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[180:183], v[72:75], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s77                                   
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[180:183], v[76:79], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[176:179], v[80:83], a[200:203], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[176:179], v[84:87], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[88:91], a[208:211], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[92:95], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[88:91], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[92:95], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[176:179], v[96:99], a[216:219], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[176:179], v[100:103], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[96:99], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[100:103], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[104:107], a[128:131], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[108:111], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[188:191], v[104:107], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[188:191], v[108:111], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[184:187], v[112:115], a[136:139], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[184:187], v[116:119], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[188:191], v[112:115], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[188:191], v[116:119], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[184:187], v[120:123], a[144:147], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[184:187], v[124:127], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[188:191], v[120:123], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[188:191], v[124:127], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[184:187], v[128:131], a[152:155], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[184:187], v[132:135], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 0                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[188:191], v[128:131], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[188:191], v[132:135], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[192:195], v[104:107], a[192:195], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[192:195], v[108:111], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[196:199], v[104:107], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[196:199], v[108:111], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[192:195], v[112:115], a[200:203], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[192:195], v[116:119], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[196:199], v[112:115], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[196:199], v[116:119], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[192:195], v[120:123], a[208:211], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[192:195], v[124:127], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[120:123], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[124:127], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[192:195], v[128:131], a[216:219], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[192:195], v[132:135], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[128:131], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[132:135], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_branch label_03F3                                        
+	
+label_094A:
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[140:143], v[8:11], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[140:143], v[12:15], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[16:19], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[20:23], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[140:143], v[24:27], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[140:143], v[28:31], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[136:139], v[32:35], a[24:27], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[136:139], v[36:39], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[32:35], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[36:39], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[8:11], a[64:67], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[12:15], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[148:151], v[8:11], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[148:151], v[12:15], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[144:147], v[16:19], a[72:75], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[144:147], v[20:23], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[16:19], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[20:23], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[24:27], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[28:31], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[148:151], v[24:27], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[148:151], v[28:31], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[144:147], v[32:35], a[88:91], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[144:147], v[36:39], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[40:43], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[44:47], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v233, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[156:159], v[40:43], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[156:159], v[44:47], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[48:51], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[52:55], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[48:51], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[52:55], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[156:159], v[56:59], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[156:159], v[60:63], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[152:155], v[64:67], a[24:27], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[152:155], v[68:71], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[40:43], a[64:67], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[44:47], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[164:167], v[40:43], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[164:167], v[44:47], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[160:163], v[48:51], a[72:75], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[160:163], v[52:55], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[48:51], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[52:55], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[56:59], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[60:63], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[164:167], v[56:59], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[164:167], v[60:63], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[160:163], v[64:67], a[88:91], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[160:163], v[68:71], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s76                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[140:143], v[72:75], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[140:143], v[76:79], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[80:83], a[136:139], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[84:87], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[80:83], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[84:87], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[88:91], a[144:147], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[92:95], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[140:143], v[88:91], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[140:143], v[92:95], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[136:139], v[96:99], a[152:155], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[136:139], v[100:103], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[96:99], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[100:103], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[72:75], a[192:195], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[76:79], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s77                                       
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[148:151], v[72:75], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[148:151], v[76:79], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[144:147], v[80:83], a[200:203], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[144:147], v[84:87], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[148:151], v[80:83], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[148:151], v[84:87], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[88:91], a[208:211], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[92:95], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[148:151], v[88:91], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[148:151], v[92:95], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[144:147], v[96:99], a[216:219], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[144:147], v[100:103], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[148:151], v[96:99], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[148:151], v[100:103], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[104:107], a[128:131], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[108:111], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[156:159], v[104:107], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:2304                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[156:159], v[108:111], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[112:115], a[136:139], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:2560                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[116:119], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[112:115], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:2816                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[116:119], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[120:123], a[144:147], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[124:127], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[156:159], v[120:123], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[156:159], v[124:127], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[152:155], v[128:131], a[152:155], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 1                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[152:155], v[132:135], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[128:131], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[132:135], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[104:107], a[192:195], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[108:111], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[164:167], v[104:107], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[164:167], v[108:111], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[160:163], v[112:115], a[200:203], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[160:163], v[116:119], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[164:167], v[112:115], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[164:167], v[116:119], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[120:123], a[208:211], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[124:127], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[164:167], v[120:123], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[164:167], v[124:127], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[160:163], v[128:131], a[216:219], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[160:163], v[132:135], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[164:167], v[128:131], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[164:167], v[132:135], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[172:175], v[8:11], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[172:175], v[12:15], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[168:171], v[16:19], a[8:11], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[168:171], v[20:23], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[16:19], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v221 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[20:23], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[172:175], v[24:27], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[172:175], v[28:31], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[168:171], v[32:35], a[24:27], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[168:171], v[36:39], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[32:35], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v221 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[36:39], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[8:11], a[64:67], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[12:15], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[180:183], v[8:11], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[180:183], v[12:15], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[176:179], v[16:19], a[72:75], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[176:179], v[20:23], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v221 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[24:27], a[80:83], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[28:31], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[24:27], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[28:31], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[176:179], v[32:35], a[88:91], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[176:179], v[36:39], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[32:35], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[36:39], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[40:43], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[44:47], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v233, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[188:191], v[40:43], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:3328                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[188:191], v[44:47], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[184:187], v[48:51], a[8:11], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:3584                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[184:187], v[52:55], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[48:51], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:3840                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[52:55], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[56:59], a[16:19], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[60:63], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[188:191], v[56:59], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[188:191], v[60:63], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[184:187], v[64:67], a[24:27], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[184:187], v[68:71], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[40:43], a[64:67], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[44:47], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[196:199], v[40:43], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[196:199], v[44:47], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[192:195], v[48:51], a[72:75], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[192:195], v[52:55], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[48:51], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[52:55], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[56:59], a[80:83], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[60:63], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[56:59], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[60:63], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[192:195], v[64:67], a[88:91], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[192:195], v[68:71], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[72:75], a[128:131], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[76:79], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s76                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[172:175], v[72:75], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[172:175], v[76:79], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[168:171], v[80:83], a[136:139], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[168:171], v[84:87], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[172:175], v[80:83], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[172:175], v[84:87], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[88:91], a[144:147], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[92:95], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[172:175], v[88:91], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[172:175], v[92:95], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[168:171], v[96:99], a[152:155], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[168:171], v[100:103], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[96:99], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[100:103], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[176:179], v[72:75], a[192:195], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[176:179], v[76:79], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s77                                   
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[180:183], v[72:75], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[180:183], v[76:79], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[176:179], v[80:83], a[200:203], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[176:179], v[84:87], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[88:91], a[208:211], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[92:95], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[88:91], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[92:95], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[176:179], v[96:99], a[216:219], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[176:179], v[100:103], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[96:99], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[100:103], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[104:107], a[128:131], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[108:111], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[188:191], v[104:107], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[188:191], v[108:111], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[184:187], v[112:115], a[136:139], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[184:187], v[116:119], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[188:191], v[112:115], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[188:191], v[116:119], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[184:187], v[120:123], a[144:147], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[184:187], v[124:127], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[188:191], v[120:123], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[188:191], v[124:127], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[184:187], v[128:131], a[152:155], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 0                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[184:187], v[132:135], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[188:191], v[128:131], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[188:191], v[132:135], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[192:195], v[104:107], a[192:195], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[192:195], v[108:111], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[196:199], v[104:107], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[196:199], v[108:111], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[192:195], v[112:115], a[200:203], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[192:195], v[116:119], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[196:199], v[112:115], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[196:199], v[116:119], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[192:195], v[120:123], a[208:211], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[192:195], v[124:127], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[120:123], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[124:127], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[192:195], v[128:131], a[216:219], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[192:195], v[132:135], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[128:131], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[132:135], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_branch label_094A                                        
+	
+label_0EA1:
+	s_mul_i32 s46, s56, 0x8400                                 
+	v_add_u32_e32 v220, s46, v220                              
+	s_lshl_b32 s46, s56, 11                                    
+	v_add_u32_e32 v224, s46, v224                              
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	s_cmp_eq_u32 s56, 0                                        
+	s_cbranch_scc1 label_0ECC                                  
+	v_mov_b32_e32 v136, v168                                   
+	v_mov_b32_e32 v137, v169                                   
+	v_mov_b32_e32 v138, v170                                   
+	v_mov_b32_e32 v139, v171                                   
+	v_mov_b32_e32 v140, v172                                   
+	v_mov_b32_e32 v141, v173                                   
+	v_mov_b32_e32 v142, v174                                   
+	v_mov_b32_e32 v143, v175                                   
+	v_mov_b32_e32 v144, v176                                   
+	v_mov_b32_e32 v145, v177                                   
+	v_mov_b32_e32 v146, v178                                   
+	v_mov_b32_e32 v147, v179                                   
+	v_mov_b32_e32 v148, v180                                   
+	v_mov_b32_e32 v149, v181                                   
+	v_mov_b32_e32 v150, v182                                   
+	v_mov_b32_e32 v151, v183                                   
+	v_mov_b32_e32 v152, v184                                   
+	v_mov_b32_e32 v153, v185                                   
+	v_mov_b32_e32 v154, v186                                   
+	v_mov_b32_e32 v155, v187                                   
+	v_mov_b32_e32 v156, v188                                   
+	v_mov_b32_e32 v157, v189                                   
+	v_mov_b32_e32 v158, v190                                   
+	v_mov_b32_e32 v159, v191                                   
+	v_mov_b32_e32 v160, v192                                   
+	v_mov_b32_e32 v161, v193                                   
+	v_mov_b32_e32 v162, v194                                   
+	v_mov_b32_e32 v163, v195                                   
+	v_mov_b32_e32 v164, v196                                   
+	v_mov_b32_e32 v165, v197                                   
+	v_mov_b32_e32 v166, v198                                   
+	v_mov_b32_e32 v167, v199                                   
+	v_mov_b32_e32 v208, v210                                   
+	v_mov_b32_e32 v209, v211                                   
+	
+label_0ECC:
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[40:43], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[140:143], v[8:11], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[156:159], v[40:43], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[8:11], a[64:67], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[40:43], a[64:67], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[148:151], v[8:11], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[164:167], v[40:43], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a0                                
+	v_accvgpr_read_b32 v213, a1                                
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a2                                
+	v_accvgpr_read_b32 v215, a3                                
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a32                               
+	v_accvgpr_read_b32 v217, a33                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a34                               
+	v_accvgpr_read_b32 v219, a35                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v235, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a64                               
+	v_accvgpr_read_b32 v213, a65                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a66                               
+	v_accvgpr_read_b32 v215, a67                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a96                               
+	v_accvgpr_read_b32 v217, a97                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a98                               
+	v_accvgpr_read_b32 v219, a99                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v235, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[44:47], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[140:143], v[12:15], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[156:159], v[44:47], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[12:15], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[44:47], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[148:151], v[12:15], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[164:167], v[44:47], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a4                                
+	v_accvgpr_read_b32 v213, a5                                
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a6                                
+	v_accvgpr_read_b32 v215, a7                                
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a36                               
+	v_accvgpr_read_b32 v217, a37                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a38                               
+	v_accvgpr_read_b32 v219, a39                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v236, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a68                               
+	v_accvgpr_read_b32 v213, a69                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a70                               
+	v_accvgpr_read_b32 v215, a71                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a100                              
+	v_accvgpr_read_b32 v217, a101                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a102                              
+	v_accvgpr_read_b32 v219, a103                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v236, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[48:51], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[16:19], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[48:51], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[144:147], v[16:19], a[72:75], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[160:163], v[48:51], a[72:75], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[16:19], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[48:51], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a8                                
+	v_accvgpr_read_b32 v213, a9                                
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a10                               
+	v_accvgpr_read_b32 v215, a11                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a40                               
+	v_accvgpr_read_b32 v217, a41                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a42                               
+	v_accvgpr_read_b32 v219, a43                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v237, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a72                               
+	v_accvgpr_read_b32 v213, a73                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a74                               
+	v_accvgpr_read_b32 v215, a75                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a104                              
+	v_accvgpr_read_b32 v217, a105                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a106                              
+	v_accvgpr_read_b32 v219, a107                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v237, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[52:55], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[20:23], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[52:55], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[144:147], v[20:23], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[160:163], v[52:55], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[20:23], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[52:55], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a12                               
+	v_accvgpr_read_b32 v213, a13                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a14                               
+	v_accvgpr_read_b32 v215, a15                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a44                               
+	v_accvgpr_read_b32 v217, a45                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a46                               
+	v_accvgpr_read_b32 v219, a47                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v238, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a76                               
+	v_accvgpr_read_b32 v213, a77                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a78                               
+	v_accvgpr_read_b32 v215, a79                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a108                              
+	v_accvgpr_read_b32 v217, a109                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a110                              
+	v_accvgpr_read_b32 v219, a111                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v238, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[140:143], v[24:27], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[156:159], v[56:59], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[24:27], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[56:59], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[148:151], v[24:27], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[164:167], v[56:59], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a16                               
+	v_accvgpr_read_b32 v213, a17                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a18                               
+	v_accvgpr_read_b32 v215, a19                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a48                               
+	v_accvgpr_read_b32 v217, a49                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a50                               
+	v_accvgpr_read_b32 v219, a51                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v239, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a80                               
+	v_accvgpr_read_b32 v213, a81                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a82                               
+	v_accvgpr_read_b32 v215, a83                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a112                              
+	v_accvgpr_read_b32 v217, a113                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a114                              
+	v_accvgpr_read_b32 v219, a115                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v239, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[140:143], v[28:31], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[156:159], v[60:63], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[28:31], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[60:63], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[148:151], v[28:31], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[164:167], v[60:63], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a20                               
+	v_accvgpr_read_b32 v213, a21                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a22                               
+	v_accvgpr_read_b32 v215, a23                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a52                               
+	v_accvgpr_read_b32 v217, a53                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a54                               
+	v_accvgpr_read_b32 v219, a55                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v240, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a84                               
+	v_accvgpr_read_b32 v213, a85                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a86                               
+	v_accvgpr_read_b32 v215, a87                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a116                              
+	v_accvgpr_read_b32 v217, a117                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a118                              
+	v_accvgpr_read_b32 v219, a119                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v240, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[136:139], v[32:35], a[24:27], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[152:155], v[64:67], a[24:27], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[32:35], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[144:147], v[32:35], a[88:91], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[160:163], v[64:67], a[88:91], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a24                               
+	v_accvgpr_read_b32 v213, a25                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a26                               
+	v_accvgpr_read_b32 v215, a27                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a56                               
+	v_accvgpr_read_b32 v217, a57                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a58                               
+	v_accvgpr_read_b32 v219, a59                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v241, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a88                               
+	v_accvgpr_read_b32 v213, a89                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a90                               
+	v_accvgpr_read_b32 v215, a91                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a120                              
+	v_accvgpr_read_b32 v217, a121                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a122                              
+	v_accvgpr_read_b32 v219, a123                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v241, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[136:139], v[36:39], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[152:155], v[68:71], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[36:39], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[144:147], v[36:39], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[160:163], v[68:71], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a28                               
+	v_accvgpr_read_b32 v213, a29                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a30                               
+	v_accvgpr_read_b32 v215, a31                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a60                               
+	v_accvgpr_read_b32 v217, a61                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a62                               
+	v_accvgpr_read_b32 v219, a63                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v242, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a92                               
+	v_accvgpr_read_b32 v213, a93                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a94                               
+	v_accvgpr_read_b32 v215, a95                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a124                              
+	v_accvgpr_read_b32 v217, a125                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a126                              
+	v_accvgpr_read_b32 v219, a127                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v242, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[104:107], a[128:131], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[140:143], v[72:75], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[156:159], v[104:107], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[72:75], a[192:195], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[104:107], a[192:195], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[148:151], v[72:75], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[164:167], v[104:107], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a128                              
+	v_accvgpr_read_b32 v213, a129                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a130                              
+	v_accvgpr_read_b32 v215, a131                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a160                              
+	v_accvgpr_read_b32 v217, a161                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a162                              
+	v_accvgpr_read_b32 v219, a163                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v243, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a192                              
+	v_accvgpr_read_b32 v213, a193                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a194                              
+	v_accvgpr_read_b32 v215, a195                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a224                              
+	v_accvgpr_read_b32 v217, a225                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a226                              
+	v_accvgpr_read_b32 v219, a227                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v243, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[108:111], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[140:143], v[76:79], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[156:159], v[108:111], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[76:79], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[108:111], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[148:151], v[76:79], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[164:167], v[108:111], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a132                              
+	v_accvgpr_read_b32 v213, a133                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a134                              
+	v_accvgpr_read_b32 v215, a135                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a164                              
+	v_accvgpr_read_b32 v217, a165                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a166                              
+	v_accvgpr_read_b32 v219, a167                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v244, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a196                              
+	v_accvgpr_read_b32 v213, a197                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a198                              
+	v_accvgpr_read_b32 v215, a199                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a228                              
+	v_accvgpr_read_b32 v217, a229                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a230                              
+	v_accvgpr_read_b32 v219, a231                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v244, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[80:83], a[136:139], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[112:115], a[136:139], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[80:83], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[112:115], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[144:147], v[80:83], a[200:203], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[160:163], v[112:115], a[200:203], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[148:151], v[80:83], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[164:167], v[112:115], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a136                              
+	v_accvgpr_read_b32 v213, a137                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a138                              
+	v_accvgpr_read_b32 v215, a139                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a168                              
+	v_accvgpr_read_b32 v217, a169                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a170                              
+	v_accvgpr_read_b32 v219, a171                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v245, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a200                              
+	v_accvgpr_read_b32 v213, a201                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a202                              
+	v_accvgpr_read_b32 v215, a203                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a232                              
+	v_accvgpr_read_b32 v217, a233                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a234                              
+	v_accvgpr_read_b32 v219, a235                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v245, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[84:87], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[116:119], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[84:87], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[116:119], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[144:147], v[84:87], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[160:163], v[116:119], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[148:151], v[84:87], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[164:167], v[116:119], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a140                              
+	v_accvgpr_read_b32 v213, a141                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a142                              
+	v_accvgpr_read_b32 v215, a143                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a172                              
+	v_accvgpr_read_b32 v217, a173                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a174                              
+	v_accvgpr_read_b32 v219, a175                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v246, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a204                              
+	v_accvgpr_read_b32 v213, a205                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a206                              
+	v_accvgpr_read_b32 v215, a207                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a236                              
+	v_accvgpr_read_b32 v217, a237                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a238                              
+	v_accvgpr_read_b32 v219, a239                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v246, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[88:91], a[144:147], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[120:123], a[144:147], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[140:143], v[88:91], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[156:159], v[120:123], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[88:91], a[208:211], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[120:123], a[208:211], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[148:151], v[88:91], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[164:167], v[120:123], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a144                              
+	v_accvgpr_read_b32 v213, a145                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a146                              
+	v_accvgpr_read_b32 v215, a147                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a176                              
+	v_accvgpr_read_b32 v217, a177                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a178                              
+	v_accvgpr_read_b32 v219, a179                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v247, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a208                              
+	v_accvgpr_read_b32 v213, a209                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a210                              
+	v_accvgpr_read_b32 v215, a211                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a240                              
+	v_accvgpr_read_b32 v217, a241                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a242                              
+	v_accvgpr_read_b32 v219, a243                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v247, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[92:95], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[124:127], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[140:143], v[92:95], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[156:159], v[124:127], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[92:95], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[124:127], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[148:151], v[92:95], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[164:167], v[124:127], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a148                              
+	v_accvgpr_read_b32 v213, a149                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a150                              
+	v_accvgpr_read_b32 v215, a151                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a180                              
+	v_accvgpr_read_b32 v217, a181                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a182                              
+	v_accvgpr_read_b32 v219, a183                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v248, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a212                              
+	v_accvgpr_read_b32 v213, a213                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a214                              
+	v_accvgpr_read_b32 v215, a215                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a244                              
+	v_accvgpr_read_b32 v217, a245                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a246                              
+	v_accvgpr_read_b32 v219, a247                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v248, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[136:139], v[96:99], a[152:155], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[152:155], v[128:131], a[152:155], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[96:99], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[128:131], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[144:147], v[96:99], a[216:219], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[160:163], v[128:131], a[216:219], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[148:151], v[96:99], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[164:167], v[128:131], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a152                              
+	v_accvgpr_read_b32 v213, a153                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a154                              
+	v_accvgpr_read_b32 v215, a155                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a184                              
+	v_accvgpr_read_b32 v217, a185                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a186                              
+	v_accvgpr_read_b32 v219, a187                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v249, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a216                              
+	v_accvgpr_read_b32 v213, a217                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a218                              
+	v_accvgpr_read_b32 v215, a219                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a248                              
+	v_accvgpr_read_b32 v217, a249                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a250                              
+	v_accvgpr_read_b32 v219, a251                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v249, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[136:139], v[100:103], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[152:155], v[132:135], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[100:103], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[132:135], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[144:147], v[100:103], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[160:163], v[132:135], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[148:151], v[100:103], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[164:167], v[132:135], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a156                              
+	v_accvgpr_read_b32 v213, a157                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a158                              
+	v_accvgpr_read_b32 v215, a159                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a188                              
+	v_accvgpr_read_b32 v217, a189                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a190                              
+	v_accvgpr_read_b32 v219, a191                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v250, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a220                              
+	v_accvgpr_read_b32 v213, a221                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a222                              
+	v_accvgpr_read_b32 v215, a223                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a252                              
+	v_accvgpr_read_b32 v217, a253                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a254                              
+	v_accvgpr_read_b32 v219, a255                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v250, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB.s
@@ -1,0 +1,3162 @@
+// Auto-generated from FP4_GEMM_1TG_4W_MT256x256x256_B_Shuffle_Epilogue.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s32, s[0:1], 0x40                             
+	s_load_dword s33, s[0:1], 0x50                             
+	s_load_dword s34, s[0:1], 0x80                             
+	s_load_dword s35, s[0:1], 0xa0                             
+	s_load_dword s36, s[0:1], 0xc0                             
+	s_load_dword s39, s[0:1], 0xe0                             
+	s_load_dword s40, s[0:1], 0xf0                             
+	s_load_dword s41, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s37, s[0:1], 0x130                            
+	s_load_dword s38, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s53, s2                                          
+	s_mov_b32 s54, s3                                          
+	v_readfirstlane_b32 s42, v3                                
+	s_mov_b32 s68, 0x80                                        
+	s_mov_b32 s69, 0x800                                       
+	s_mov_b32 s70, 0x100                                       
+	s_mov_b32 s71, 0x100                                       
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s46, s40, 0xff                                   
+	s_lshr_b32 s46, s46, 8                                     
+	s_mul_i32 s48, s46, s54                                    
+	s_add_i32 s48, s48, s53                                    
+	s_lshr_b32 s49, s46, 5                                     
+	s_lshl_b32 s49, s49, 5                                     
+	s_sub_i32 s50, s46, s49                                    
+	s_add_u32 s51, s39, 0xff                                   
+	s_lshr_b32 s51, s51, 8                                     
+	s_mul_i32 s52, s49, s51                                    
+	s_cmp_lt_i32 s48, s52                                      
+	s_cbranch_scc0 label_006B                                  
+	s_lshr_b32 s46, s48, 5                                     
+	v_cvt_f32_u32_e32 v4, s51                                  
+	s_sub_i32 s47, 0, s51                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s47, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s46, v4                                   
+	v_mul_lo_u32 v5, v4, s51                                   
+	v_sub_u32_e32 v7, s46, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s51, v7                              
+	v_subrev_u32_e32 v5, s51, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s51, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s47, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s54, s51, s47                                    
+	s_sub_i32 s54, s46, s54                                    
+	s_and_b32 s46, s48, 31                                     
+	s_lshl_b32 s53, s47, 5                                     
+	s_add_i32 s53, s53, s46                                    
+	s_branch label_008D                                        
+	
+label_006B:
+	s_sub_i32 s46, s48, s52                                    
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s54, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s54, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s46, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s46, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s54, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s47, s50, s54                                    
+	s_sub_i32 s53, s46, s47                                    
+	s_add_i32 s53, s49, s53                                    
+	
+label_008D:
+	s_lshr_b32 s35, s35, 1                                     
+	s_mov_b32 s15, 0x20000                                     
+	s_and_b32 s13, s13, 0xffff                                 
+	s_or_b32 s13, s13, 0x40000                                 
+	s_mul_i32 s14, s35, s39                                    
+	s_mov_b32 s23, 0x20000                                     
+	s_and_b32 s21, s21, 0xffff                                 
+	s_or_b32 s21, s21, 0x40000                                 
+	s_add_u32 s46, s39, 31                                     
+	s_lshr_b32 s46, s46, 5                                     
+	s_lshl_b32 s46, s46, 5                                     
+	s_mul_i32 s22, s46, s37                                    
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s35, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v212, v4                               
+	s_lshr_b32 s46, s42, 1                                     
+	s_lshl_b32 s46, s46, 3                                     
+	s_and_b32 s47, s42, 1                                      
+	s_lshl_b32 s47, s47, 1                                     
+	s_add_u32 s46, s46, s47                                    
+	s_lshl_b32 s47, s54, 8                                     
+	s_add_u32 s46, s46, s47                                    
+	s_mul_i32 s46, s35, s46                                    
+	v_add_u32_e32 v212, s46, v212                              
+	s_lshl_b32 s46, s35, 5                                     
+	v_add_u32_e32 v213, s46, v212                              
+	v_add_u32_e32 v214, s46, v213                              
+	v_add_u32_e32 v215, s46, v214                              
+	v_add_u32_e32 v216, s46, v215                              
+	v_add_u32_e32 v217, s46, v216                              
+	v_add_u32_e32 v218, s46, v217                              
+	v_add_u32_e32 v219, s46, v218                              
+	s_mul_i32 s76, 0x420, s42                                  
+	s_add_u32 s76, 0x1000, s76                                 
+	s_lshl_b32 s46, s54, 8                                     
+	s_lshl_b32 s47, s42, 5                                     
+	s_add_i32 s47, s47, s46                                    
+	s_mul_i32 s47, s47, s37                                    
+	v_lshlrev_b32_e32 v222, 2, v0                              
+	v_add_u32_e32 v222, s47, v222                              
+	s_lshl_b32 s47, s37, 7                                     
+	v_add_u32_e32 v223, s47, v222                              
+	s_lshl_b32 s77, s42, 8                                     
+	s_add_i32 s77, s77, 0                                      
+	s_mov_b32 s33, s32                                         
+	s_mov_b32 s43, 0                                           
+	s_mov_b32 s44, s41                                         
+	s_add_u32 m0, 0, s76                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	s_add_u32 m0, 0x1080, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0x2100, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	s_add_u32 m0, 0x3180, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	s_add_u32 m0, 0, s77                                       
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	s_add_u32 m0, 0x4200, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x5280, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	s_add_u32 m0, 0x6300, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	s_add_u32 m0, 0x7380, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	s_add_u32 m0, 0x400, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	s_add_u32 s45, 0x100, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	s_lshr_b32 s36, s36, 1                                     
+	s_mov_b32 s19, 0x20000                                     
+	s_and_b32 s17, s17, 0xffff                                 
+	s_or_b32 s17, s17, 0x40000                                 
+	s_mul_i32 s18, s36, s40                                    
+	s_mov_b32 s27, 0x20000                                     
+	s_and_b32 s25, s25, 0xffff                                 
+	s_or_b32 s25, s25, 0x40000                                 
+	s_mul_i32 s26, s38, s40                                    
+	s_lshl_b32 s46, s53, 8                                     
+	s_lshl_b32 s47, s42, 6                                     
+	s_add_i32 s46, s46, s47                                    
+	s_mul_i32 s46, s46, s36                                    
+	v_lshlrev_b32_e32 v225, 4, v0                              
+	v_add_u32_e32 v225, s46, v225                              
+	s_lshl_b32 s46, s36, 4                                     
+	v_add_u32_e32 v226, s46, v225                              
+	v_add_u32_e32 v227, s46, v226                              
+	v_add_u32_e32 v228, s46, v227                              
+	v_add_u32_e32 v229, 0x400, v225                            
+	v_add_u32_e32 v230, 0x400, v226                            
+	v_add_u32_e32 v231, 0x400, v227                            
+	v_add_u32_e32 v232, 0x400, v228                            
+	s_lshl_b32 s46, s53, 8                                     
+	s_lshl_b32 s47, s42, 6                                     
+	s_add_i32 s46, s46, s47                                    
+	s_mul_i32 s46, s46, s38                                    
+	v_lshlrev_b32_e32 v233, 2, v0                              
+	v_add_u32_e32 v233, s46, v233                              
+	s_mul_i32 s47, 32, s38                                     
+	v_add_u32_e32 v234, s47, v233                              
+	s_lshl_b32 s34, s34, 1                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_and_b32 s5, s5, 0xffff                                   
+	s_or_b32 s5, s5, 0x40000                                   
+	s_mul_i32 s6, s34, s39                                     
+	s_lshl_b32 s46, s53, 8                                     
+	s_lshl_b32 s47, s42, 6                                     
+	s_add_i32 s55, s46, s47                                    
+	s_lshl_b32 s46, s55, 1                                     
+	s_lshl_b32 s47, s54, 8                                     
+	s_mul_i32 s47, s47, s34                                    
+	s_add_u32 s46, s46, s47                                    
+	s_add_u32 s4, s4, s46                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_u32 s6, s6, s46                                      
+	v_and_b32_e64 v4, v0, 15                                   
+	v_mul_lo_u32 v4, v4, s34                                   
+	v_lshrrev_b32_e32 v5, 5, v0                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_lshrrev_b32_e32 v6, 4, v0                                
+	v_and_b32_e32 v6, 1, v6                                    
+	v_lshlrev_b32_e32 v6, 5, v6                                
+	v_add3_u32 v235, v4, v5, v6                                
+	s_lshl_b32 s47, s34, 4                                     
+	v_add_u32_e32 v236, s47, v235                              
+	v_add_u32_e32 v237, s47, v236                              
+	v_add_u32_e32 v238, s47, v237                              
+	v_add_u32_e32 v239, s47, v238                              
+	v_add_u32_e32 v240, s47, v239                              
+	v_add_u32_e32 v241, s47, v240                              
+	v_add_u32_e32 v242, s47, v241                              
+	v_add_u32_e32 v243, s47, v242                              
+	v_add_u32_e32 v244, s47, v243                              
+	v_add_u32_e32 v245, s47, v244                              
+	v_add_u32_e32 v246, s47, v245                              
+	v_add_u32_e32 v247, s47, v246                              
+	v_add_u32_e32 v248, s47, v247                              
+	v_add_u32_e32 v249, s47, v248                              
+	v_add_u32_e32 v250, s47, v249                              
+	buffer_load_dwordx4 v[136:139], v225, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	buffer_load_dwordx4 v[140:143], v226, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	buffer_load_dwordx4 v[160:163], v231, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	buffer_load_dwordx4 v[164:167], v232, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	buffer_load_dword v208, v233, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	buffer_load_dword v209, v234, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_add_u32 s45, 0x100, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v220, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v220, v5, v220                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v220, v6, v220                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v4, 0x1000, v4                               
+	v_add_u32_e32 v220, v4, v220                               
+	v_add_u32_e32 v221, 0x8400, v220                           
+	v_lshlrev_b32_e32 v224, 2, v0                              
+	v_add_u32_e32 v224, 0, v224                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v220                                 
+	ds_read_b128 v[40:43], v220 offset:64                      
+	s_add_u32 m0, 0x8400, s76                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	ds_read_b128 v[12:15], v220 offset:512                     
+	ds_read_b128 v[44:47], v220 offset:576                     
+	s_add_u32 m0, 0x9480, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	ds_read_b128 v[16:19], v220 offset:4224                    
+	ds_read_b128 v[48:51], v220 offset:4288                    
+	s_add_u32 m0, 0xa500, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	ds_read_b128 v[20:23], v220 offset:4736                    
+	ds_read_b128 v[52:55], v220 offset:4800                    
+	s_add_u32 m0, 0xb580, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	ds_read_b128 v[24:27], v220 offset:8448                    
+	ds_read_b128 v[56:59], v220 offset:8512                    
+	s_add_u32 m0, 0x800, s77                                   
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	ds_read_b128 v[28:31], v220 offset:8960                    
+	ds_read_b128 v[60:63], v220 offset:9024                    
+	s_add_u32 m0, 0xc600, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	ds_read_b128 v[32:35], v220 offset:12672                   
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	s_add_u32 m0, 0xd680, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	ds_read_b128 v[36:39], v220 offset:13184                   
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	s_add_u32 m0, 0xe700, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	ds_read_b32 v200, v224                                     
+	ds_read_b32 v201, v224 offset:256                          
+	s_add_u32 m0, 0xf780, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	ds_read_b32 v202, v224 offset:512                          
+	ds_read_b32 v203, v224 offset:768                          
+	s_add_u32 m0, 0xc00, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_accvgpr_write_b32 a240, 0                                
+	v_accvgpr_write_b32 a241, 0                                
+	v_accvgpr_write_b32 a242, 0                                
+	v_accvgpr_write_b32 a243, 0                                
+	v_accvgpr_write_b32 a244, 0                                
+	v_accvgpr_write_b32 a245, 0                                
+	v_accvgpr_write_b32 a246, 0                                
+	v_accvgpr_write_b32 a247, 0                                
+	v_accvgpr_write_b32 a248, 0                                
+	v_accvgpr_write_b32 a249, 0                                
+	v_accvgpr_write_b32 a250, 0                                
+	v_accvgpr_write_b32 a251, 0                                
+	v_accvgpr_write_b32 a252, 0                                
+	v_accvgpr_write_b32 a253, 0                                
+	v_accvgpr_write_b32 a254, 0                                
+	v_accvgpr_write_b32 a255, 0                                
+	s_mov_b32 s56, 0                                           
+	s_add_u32 s46, s43, 0x100                                  
+	s_cmp_lt_i32 s46, s44                                      
+	s_cbranch_scc0 label_0EA1                                  
+	s_cmp_lt_i32 s42, 2                                        
+	s_cbranch_scc0 label_094A                                  
+	
+label_03F3:
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[140:143], v[8:11], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[140:143], v[12:15], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[16:19], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[20:23], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[140:143], v[24:27], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[140:143], v[28:31], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[136:139], v[32:35], a[24:27], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[136:139], v[36:39], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[32:35], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[36:39], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[8:11], a[64:67], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[12:15], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[148:151], v[8:11], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[148:151], v[12:15], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[144:147], v[16:19], a[72:75], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[144:147], v[20:23], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[16:19], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[20:23], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[24:27], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[28:31], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[148:151], v[24:27], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[148:151], v[28:31], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[144:147], v[32:35], a[88:91], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[144:147], v[36:39], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[40:43], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[44:47], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[156:159], v[40:43], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v233, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[156:159], v[44:47], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[48:51], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[52:55], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[48:51], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[52:55], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[156:159], v[56:59], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[156:159], v[60:63], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[152:155], v[64:67], a[24:27], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[152:155], v[68:71], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[40:43], a[64:67], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[44:47], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[164:167], v[40:43], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[164:167], v[44:47], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[160:163], v[48:51], a[72:75], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[160:163], v[52:55], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[48:51], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[52:55], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[56:59], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[60:63], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[164:167], v[56:59], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[164:167], v[60:63], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[160:163], v[64:67], a[88:91], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[160:163], v[68:71], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[140:143], v[72:75], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s76                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[140:143], v[76:79], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[80:83], a[136:139], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[84:87], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[80:83], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[84:87], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[88:91], a[144:147], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[92:95], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[140:143], v[88:91], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[140:143], v[92:95], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[136:139], v[96:99], a[152:155], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[136:139], v[100:103], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[96:99], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[100:103], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[72:75], a[192:195], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[76:79], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[148:151], v[72:75], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s77                                       
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[148:151], v[76:79], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[144:147], v[80:83], a[200:203], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[144:147], v[84:87], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[148:151], v[80:83], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[148:151], v[84:87], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[88:91], a[208:211], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[92:95], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[148:151], v[88:91], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[148:151], v[92:95], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[144:147], v[96:99], a[216:219], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[144:147], v[100:103], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[148:151], v[96:99], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[148:151], v[100:103], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[104:107], a[128:131], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[108:111], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[156:159], v[104:107], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[156:159], v[108:111], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:2304                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[112:115], a[136:139], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[116:119], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:2560                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[112:115], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[116:119], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:2816                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[120:123], a[144:147], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[124:127], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[156:159], v[120:123], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[156:159], v[124:127], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[152:155], v[128:131], a[152:155], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[152:155], v[132:135], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 1                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[128:131], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[132:135], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[104:107], a[192:195], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[108:111], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[164:167], v[104:107], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[164:167], v[108:111], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[160:163], v[112:115], a[200:203], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[160:163], v[116:119], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[164:167], v[112:115], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[164:167], v[116:119], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[120:123], a[208:211], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[124:127], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[164:167], v[120:123], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[164:167], v[124:127], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[160:163], v[128:131], a[216:219], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[160:163], v[132:135], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[164:167], v[128:131], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[164:167], v[132:135], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[172:175], v[8:11], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[172:175], v[12:15], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[168:171], v[16:19], a[8:11], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[168:171], v[20:23], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[16:19], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[20:23], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v221 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[172:175], v[24:27], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[172:175], v[28:31], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[168:171], v[32:35], a[24:27], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[168:171], v[36:39], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[32:35], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[36:39], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v221 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[8:11], a[64:67], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[12:15], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[180:183], v[8:11], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[180:183], v[12:15], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[176:179], v[16:19], a[72:75], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[176:179], v[20:23], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v221 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[24:27], a[80:83], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[28:31], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[24:27], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[28:31], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[176:179], v[32:35], a[88:91], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[176:179], v[36:39], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[32:35], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[36:39], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[40:43], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[44:47], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[188:191], v[40:43], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v233, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[188:191], v[44:47], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:3328                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[184:187], v[48:51], a[8:11], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[184:187], v[52:55], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:3584                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[48:51], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[52:55], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:3840                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[56:59], a[16:19], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[60:63], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[188:191], v[56:59], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[188:191], v[60:63], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[184:187], v[64:67], a[24:27], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[184:187], v[68:71], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[40:43], a[64:67], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[44:47], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[196:199], v[40:43], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[196:199], v[44:47], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[192:195], v[48:51], a[72:75], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[192:195], v[52:55], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[48:51], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[52:55], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[56:59], a[80:83], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[60:63], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[56:59], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[60:63], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[192:195], v[64:67], a[88:91], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[192:195], v[68:71], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[72:75], a[128:131], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[76:79], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[172:175], v[72:75], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s76                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[172:175], v[76:79], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[168:171], v[80:83], a[136:139], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[168:171], v[84:87], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[172:175], v[80:83], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[172:175], v[84:87], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[88:91], a[144:147], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[92:95], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[172:175], v[88:91], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[172:175], v[92:95], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[168:171], v[96:99], a[152:155], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[168:171], v[100:103], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[96:99], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[100:103], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[176:179], v[72:75], a[192:195], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[176:179], v[76:79], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[180:183], v[72:75], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s77                                   
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[180:183], v[76:79], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[176:179], v[80:83], a[200:203], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[176:179], v[84:87], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[88:91], a[208:211], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[92:95], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[88:91], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[92:95], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[176:179], v[96:99], a[216:219], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[176:179], v[100:103], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[96:99], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[100:103], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[104:107], a[128:131], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[108:111], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[188:191], v[104:107], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[188:191], v[108:111], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[184:187], v[112:115], a[136:139], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[184:187], v[116:119], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[188:191], v[112:115], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[188:191], v[116:119], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[184:187], v[120:123], a[144:147], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[184:187], v[124:127], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[188:191], v[120:123], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[188:191], v[124:127], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[184:187], v[128:131], a[152:155], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[184:187], v[132:135], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 0                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[188:191], v[128:131], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[188:191], v[132:135], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[192:195], v[104:107], a[192:195], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[192:195], v[108:111], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[196:199], v[104:107], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[196:199], v[108:111], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[192:195], v[112:115], a[200:203], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[192:195], v[116:119], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[196:199], v[112:115], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[196:199], v[116:119], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[192:195], v[120:123], a[208:211], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[192:195], v[124:127], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[120:123], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[124:127], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[192:195], v[128:131], a[216:219], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[192:195], v[132:135], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[128:131], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[132:135], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_branch label_03F3                                        
+	
+label_094A:
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[140:143], v[8:11], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[140:143], v[12:15], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[16:19], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[20:23], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[140:143], v[24:27], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[140:143], v[28:31], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[136:139], v[32:35], a[24:27], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[136:139], v[36:39], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[32:35], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[36:39], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[8:11], a[64:67], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[12:15], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[184:187], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[148:151], v[8:11], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[148:151], v[12:15], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[144:147], v[16:19], a[72:75], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[144:147], v[20:23], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[16:19], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[20:23], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[24:27], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[28:31], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[148:151], v[24:27], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[148:151], v[28:31], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[144:147], v[32:35], a[88:91], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[144:147], v[36:39], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[40:43], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[44:47], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v233, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[156:159], v[40:43], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[156:159], v[44:47], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[48:51], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[52:55], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[48:51], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[52:55], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[156:159], v[56:59], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[156:159], v[60:63], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[152:155], v[64:67], a[24:27], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[152:155], v[68:71], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[40:43], a[64:67], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[44:47], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[164:167], v[40:43], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[164:167], v[44:47], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[160:163], v[48:51], a[72:75], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[160:163], v[52:55], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[48:51], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[52:55], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[56:59], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[60:63], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[164:167], v[56:59], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[164:167], v[60:63], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[160:163], v[64:67], a[88:91], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[160:163], v[68:71], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v221                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s76                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[140:143], v[72:75], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v221 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[140:143], v[76:79], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[80:83], a[136:139], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v221 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[84:87], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[80:83], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v221 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[84:87], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[88:91], a[144:147], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v221 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[92:95], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[140:143], v[88:91], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v221 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[140:143], v[92:95], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[136:139], v[96:99], a[152:155], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v221 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[136:139], v[100:103], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[96:99], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v221 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[100:103], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[72:75], a[192:195], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v221 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[76:79], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s77                                       
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[148:151], v[72:75], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v221 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[148:151], v[76:79], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[144:147], v[80:83], a[200:203], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v221 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[144:147], v[84:87], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[148:151], v[80:83], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v221 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[148:151], v[84:87], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[88:91], a[208:211], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v221 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[92:95], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[148:151], v[88:91], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v221 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[148:151], v[92:95], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[144:147], v[96:99], a[216:219], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v221 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[144:147], v[100:103], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[148:151], v[96:99], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v221 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[148:151], v[100:103], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[104:107], a[128:131], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[108:111], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[156:159], v[104:107], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:2304                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[156:159], v[108:111], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[112:115], a[136:139], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:2560                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[116:119], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[112:115], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:2816                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[116:119], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[120:123], a[144:147], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[124:127], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[156:159], v[120:123], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[156:159], v[124:127], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[152:155], v[128:131], a[152:155], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 1                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[152:155], v[132:135], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[128:131], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[132:135], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[104:107], a[192:195], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[108:111], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[164:167], v[104:107], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[164:167], v[108:111], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[160:163], v[112:115], a[200:203], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[160:163], v[116:119], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[164:167], v[112:115], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[164:167], v[116:119], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[120:123], a[208:211], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[124:127], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[164:167], v[120:123], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[164:167], v[124:127], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[160:163], v[128:131], a[216:219], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[160:163], v[132:135], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[164:167], v[128:131], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[164:167], v[132:135], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[168:171], v[8:11], a[0:3], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v221 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[168:171], v[12:15], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[172:175], v[8:11], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v221 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[172:175], v[12:15], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x200, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[168:171], v[16:19], a[8:11], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v221 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[168:171], v[20:23], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[172:175], v[16:19], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v221 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[172:175], v[20:23], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	s_cselect_b32 s71, s71, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[24:27], a[16:19], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v221 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[28:31], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[172:175], v[24:27], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v221 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[172:175], v[28:31], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[168:171], v[32:35], a[24:27], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v221 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[168:171], v[36:39], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[172:175], v[32:35], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v221 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[172:175], v[36:39], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[8:11], a[64:67], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v221 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[12:15], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[180:183], v[8:11], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v221 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[180:183], v[12:15], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[176:179], v[16:19], a[72:75], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v221 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[176:179], v[20:23], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v221 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[176:179], v[24:27], a[80:83], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v221 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[176:179], v[28:31], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[180:183], v[24:27], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v221 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[180:183], v[28:31], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[176:179], v[32:35], a[88:91], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v221 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[176:179], v[36:39], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[32:35], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v221 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[36:39], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[184:187], v[40:43], a[0:3], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[184:187], v[44:47], a[4:7], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v233, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[188:191], v[40:43], a[32:35], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:3328                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[188:191], v[44:47], a[36:39], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[184:187], v[48:51], a[8:11], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:3584                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[184:187], v[52:55], a[12:15], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[48:51], a[40:43], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:3840                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[52:55], a[44:47], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s69                                    
+	s_addc_u32 s17, s17, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[184:187], v[56:59], a[16:19], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s71                                    
+	s_addc_u32 s25, s25, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[184:187], v[60:63], a[20:23], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s69                                    
+	s_sub_u32 s26, s26, s71                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[188:191], v[56:59], a[48:51], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[188:191], v[60:63], a[52:55], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[184:187], v[64:67], a[24:27], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[184:187], v[68:71], a[28:31], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[188:191], v[64:67], a[56:59], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[188:191], v[68:71], a[60:63], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[192:195], v[40:43], a[64:67], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[192:195], v[44:47], a[68:71], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[196:199], v[40:43], a[96:99], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[196:199], v[44:47], a[100:103], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[192:195], v[48:51], a[72:75], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[192:195], v[52:55], a[76:79], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[196:199], v[48:51], a[104:107], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[196:199], v[52:55], a[108:111], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[56:59], a[80:83], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[60:63], a[84:87], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[196:199], v[56:59], a[112:115], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[196:199], v[60:63], a[116:119], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[192:195], v[64:67], a[88:91], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[192:195], v[68:71], a[92:95], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15) lgkmcnt(0)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[168:171], v[72:75], a[128:131], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v220                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[168:171], v[76:79], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s76                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[172:175], v[72:75], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v220 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[172:175], v[76:79], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[168:171], v[80:83], a[136:139], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v220 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[168:171], v[84:87], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s76                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[172:175], v[80:83], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v220 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[172:175], v[84:87], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[88:91], a[144:147], v210, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v220 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[92:95], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s76                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[172:175], v[88:91], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v220 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[172:175], v[92:95], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[168:171], v[96:99], a[152:155], v210, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v220 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[168:171], v[100:103], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s76                                  
+	buffer_load_dwordx4 v215, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[172:175], v[96:99], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v220 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[172:175], v[100:103], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[176:179], v[72:75], a[192:195], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v220 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[176:179], v[76:79], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s77                                   
+	buffer_load_dword v222, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[180:183], v[72:75], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v220 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[180:183], v[76:79], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[176:179], v[80:83], a[200:203], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v220 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[176:179], v[84:87], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc600, s76                                  
+	buffer_load_dwordx4 v216, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[80:83], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v220 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[84:87], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[88:91], a[208:211], v211, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v220 offset:12672                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[92:95], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xd680, s76                                  
+	buffer_load_dwordx4 v217, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[180:183], v[88:91], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v220 offset:12736                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[180:183], v[92:95], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[176:179], v[96:99], a[216:219], v211, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v220 offset:13184                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[176:179], v[100:103], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xe700, s76                                  
+	buffer_load_dwordx4 v218, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[180:183], v[96:99], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v220 offset:13248                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[180:183], v[100:103], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[104:107], a[128:131], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v200, v224                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[108:111], a[132:135], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xf780, s76                                  
+	buffer_load_dwordx4 v219, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[188:191], v[104:107], a[160:163], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v224 offset:256                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[188:191], v[108:111], a[164:167], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[184:187], v[112:115], a[136:139], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v202, v224 offset:512                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[184:187], v[116:119], a[140:143], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s77                                   
+	buffer_load_dword v223, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[188:191], v[112:115], a[168:171], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v224 offset:768                          
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[188:191], v[116:119], a[172:175], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s45, 0x300, s43                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[184:187], v[120:123], a[144:147], v210, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_cselect_b32 s70, s70, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[184:187], v[124:127], a[148:151], v210, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s68                                    
+	s_addc_u32 s13, s13, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[188:191], v[120:123], a[176:179], v210, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s70                                    
+	s_addc_u32 s21, s21, 0                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[188:191], v[124:127], a[180:183], v210, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s68                                    
+	s_sub_u32 s22, s22, s70                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[184:187], v[128:131], a[152:155], v210, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s56, 0                                           
+	s_addk_i32 s43, 0x100                                      
+	s_add_u32 s45, s43, 0x100                                  
+	s_cmp_lt_i32 s45, s44                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[184:187], v[132:135], a[156:159], v210, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[188:191], v[128:131], a[184:187], v210, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[188:191], v[132:135], a[188:191], v210, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[192:195], v[104:107], a[192:195], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[192:195], v[108:111], a[196:199], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[196:199], v[104:107], a[224:227], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[196:199], v[108:111], a[228:231], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[192:195], v[112:115], a[200:203], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[192:195], v[116:119], a[204:207], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[196:199], v[112:115], a[232:235], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[196:199], v[116:119], a[236:239], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[192:195], v[120:123], a[208:211], v211, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[192:195], v[124:127], a[212:215], v211, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[196:199], v[120:123], a[240:243], v211, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[196:199], v[124:127], a[244:247], v211, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[192:195], v[128:131], a[216:219], v211, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[192:195], v[132:135], a[220:223], v211, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[128:131], a[248:251], v211, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[132:135], a[252:255], v211, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cbranch_scc0 label_0EA1                                  
+	s_branch label_094A                                        
+	
+label_0EA1:
+	s_mul_i32 s46, s56, 0x8400                                 
+	v_add_u32_e32 v220, s46, v220                              
+	s_lshl_b32 s46, s56, 11                                    
+	v_add_u32_e32 v224, s46, v224                              
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	s_cmp_eq_u32 s56, 0                                        
+	s_cbranch_scc1 label_0ECC                                  
+	v_mov_b32_e32 v136, v168                                   
+	v_mov_b32_e32 v137, v169                                   
+	v_mov_b32_e32 v138, v170                                   
+	v_mov_b32_e32 v139, v171                                   
+	v_mov_b32_e32 v140, v172                                   
+	v_mov_b32_e32 v141, v173                                   
+	v_mov_b32_e32 v142, v174                                   
+	v_mov_b32_e32 v143, v175                                   
+	v_mov_b32_e32 v144, v176                                   
+	v_mov_b32_e32 v145, v177                                   
+	v_mov_b32_e32 v146, v178                                   
+	v_mov_b32_e32 v147, v179                                   
+	v_mov_b32_e32 v148, v180                                   
+	v_mov_b32_e32 v149, v181                                   
+	v_mov_b32_e32 v150, v182                                   
+	v_mov_b32_e32 v151, v183                                   
+	v_mov_b32_e32 v152, v184                                   
+	v_mov_b32_e32 v153, v185                                   
+	v_mov_b32_e32 v154, v186                                   
+	v_mov_b32_e32 v155, v187                                   
+	v_mov_b32_e32 v156, v188                                   
+	v_mov_b32_e32 v157, v189                                   
+	v_mov_b32_e32 v158, v190                                   
+	v_mov_b32_e32 v159, v191                                   
+	v_mov_b32_e32 v160, v192                                   
+	v_mov_b32_e32 v161, v193                                   
+	v_mov_b32_e32 v162, v194                                   
+	v_mov_b32_e32 v163, v195                                   
+	v_mov_b32_e32 v164, v196                                   
+	v_mov_b32_e32 v165, v197                                   
+	v_mov_b32_e32 v166, v198                                   
+	v_mov_b32_e32 v167, v199                                   
+	v_mov_b32_e32 v208, v210                                   
+	v_mov_b32_e32 v209, v211                                   
+	
+label_0ECC:
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v220 offset:16896                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[40:43], a[0:3], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[140:143], v[8:11], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[104:107], v220 offset:16960                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[156:159], v[40:43], a[32:35], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[8:11], a[64:67], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v220 offset:17408                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[160:163], v[40:43], a[64:67], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[148:151], v[8:11], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[108:111], v220 offset:17472                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[164:167], v[40:43], a[96:99], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a0                                
+	v_accvgpr_read_b32 v213, a1                                
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a2                                
+	v_accvgpr_read_b32 v215, a3                                
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a32                               
+	v_accvgpr_read_b32 v217, a33                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a34                               
+	v_accvgpr_read_b32 v219, a35                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v235, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a64                               
+	v_accvgpr_read_b32 v213, a65                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a66                               
+	v_accvgpr_read_b32 v215, a67                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a96                               
+	v_accvgpr_read_b32 v217, a97                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a98                               
+	v_accvgpr_read_b32 v219, a99                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v235, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v220 offset:21120                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[44:47], a[4:7], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[140:143], v[12:15], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[112:115], v220 offset:21184                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[156:159], v[44:47], a[36:39], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[12:15], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v220 offset:21632                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[160:163], v[44:47], a[68:71], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[148:151], v[12:15], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[116:119], v220 offset:21696                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[164:167], v[44:47], a[100:103], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a4                                
+	v_accvgpr_read_b32 v213, a5                                
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a6                                
+	v_accvgpr_read_b32 v215, a7                                
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a36                               
+	v_accvgpr_read_b32 v217, a37                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a38                               
+	v_accvgpr_read_b32 v219, a39                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v236, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a68                               
+	v_accvgpr_read_b32 v213, a69                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a70                               
+	v_accvgpr_read_b32 v215, a71                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a100                              
+	v_accvgpr_read_b32 v217, a101                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a102                              
+	v_accvgpr_read_b32 v219, a103                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v236, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[136:139], v[16:19], a[8:11], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v220 offset:25344                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[152:155], v[48:51], a[8:11], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[16:19], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[120:123], v220 offset:25408                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[48:51], a[40:43], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[144:147], v[16:19], a[72:75], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v220 offset:25856                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[160:163], v[48:51], a[72:75], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[16:19], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[124:127], v220 offset:25920                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[48:51], a[104:107], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a8                                
+	v_accvgpr_read_b32 v213, a9                                
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a10                               
+	v_accvgpr_read_b32 v215, a11                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a40                               
+	v_accvgpr_read_b32 v217, a41                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a42                               
+	v_accvgpr_read_b32 v219, a43                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v237, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a72                               
+	v_accvgpr_read_b32 v213, a73                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a74                               
+	v_accvgpr_read_b32 v215, a75                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a104                              
+	v_accvgpr_read_b32 v217, a105                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a106                              
+	v_accvgpr_read_b32 v219, a107                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v237, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[136:139], v[20:23], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v220 offset:29568                   
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[152:155], v[52:55], a[12:15], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[20:23], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[128:131], v220 offset:29632                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[52:55], a[44:47], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[144:147], v[20:23], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v220 offset:30080                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[160:163], v[52:55], a[76:79], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[20:23], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[132:135], v220 offset:30144                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[52:55], a[108:111], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a12                               
+	v_accvgpr_read_b32 v213, a13                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a14                               
+	v_accvgpr_read_b32 v215, a15                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a44                               
+	v_accvgpr_read_b32 v217, a45                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a46                               
+	v_accvgpr_read_b32 v219, a47                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v238, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a76                               
+	v_accvgpr_read_b32 v213, a77                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a78                               
+	v_accvgpr_read_b32 v215, a79                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a108                              
+	v_accvgpr_read_b32 v217, a109                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a110                              
+	v_accvgpr_read_b32 v219, a111                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v238, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v224 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[140:143], v[24:27], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v205, v224 offset:1280                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[156:159], v[56:59], a[48:51], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[24:27], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v206, v224 offset:1536                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[56:59], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[148:151], v[24:27], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b32 v207, v224 offset:1792                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[164:167], v[56:59], a[112:115], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a16                               
+	v_accvgpr_read_b32 v213, a17                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a18                               
+	v_accvgpr_read_b32 v215, a19                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a48                               
+	v_accvgpr_read_b32 v217, a49                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a50                               
+	v_accvgpr_read_b32 v219, a51                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v239, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a80                               
+	v_accvgpr_read_b32 v213, a81                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a82                               
+	v_accvgpr_read_b32 v215, a83                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a112                              
+	v_accvgpr_read_b32 v217, a113                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a114                              
+	v_accvgpr_read_b32 v219, a115                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v239, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[140:143], v[28:31], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[156:159], v[60:63], a[52:55], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[28:31], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[60:63], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[148:151], v[28:31], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[164:167], v[60:63], a[116:119], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a20                               
+	v_accvgpr_read_b32 v213, a21                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a22                               
+	v_accvgpr_read_b32 v215, a23                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a52                               
+	v_accvgpr_read_b32 v217, a53                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a54                               
+	v_accvgpr_read_b32 v219, a55                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v240, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a84                               
+	v_accvgpr_read_b32 v213, a85                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a86                               
+	v_accvgpr_read_b32 v215, a87                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a116                              
+	v_accvgpr_read_b32 v217, a117                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a118                              
+	v_accvgpr_read_b32 v219, a119                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v240, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[136:139], v[32:35], a[24:27], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[152:155], v[64:67], a[24:27], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[140:143], v[32:35], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[64:67], a[56:59], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[144:147], v[32:35], a[88:91], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[160:163], v[64:67], a[88:91], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[64:67], a[120:123], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a24                               
+	v_accvgpr_read_b32 v213, a25                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a26                               
+	v_accvgpr_read_b32 v215, a27                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a56                               
+	v_accvgpr_read_b32 v217, a57                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a58                               
+	v_accvgpr_read_b32 v219, a59                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v241, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a88                               
+	v_accvgpr_read_b32 v213, a89                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a90                               
+	v_accvgpr_read_b32 v215, a91                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a120                              
+	v_accvgpr_read_b32 v217, a121                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a122                              
+	v_accvgpr_read_b32 v219, a123                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v241, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[136:139], v[36:39], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[152:155], v[68:71], a[28:31], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[140:143], v[36:39], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[68:71], a[60:63], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[144:147], v[36:39], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[160:163], v[68:71], a[92:95], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[68:71], a[124:127], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a28                               
+	v_accvgpr_read_b32 v213, a29                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a30                               
+	v_accvgpr_read_b32 v215, a31                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a60                               
+	v_accvgpr_read_b32 v217, a61                               
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a62                               
+	v_accvgpr_read_b32 v219, a63                               
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v242, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a92                               
+	v_accvgpr_read_b32 v213, a93                               
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a94                               
+	v_accvgpr_read_b32 v215, a95                               
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a124                              
+	v_accvgpr_read_b32 v217, a125                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a126                              
+	v_accvgpr_read_b32 v219, a127                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v242, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[72:75], a[128:131], v208, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[104:107], a[128:131], v208, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[140:143], v[72:75], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[156:159], v[104:107], a[160:163], v208, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[72:75], a[192:195], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[104:107], a[192:195], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[148:151], v[72:75], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[164:167], v[104:107], a[224:227], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a128                              
+	v_accvgpr_read_b32 v213, a129                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a130                              
+	v_accvgpr_read_b32 v215, a131                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a160                              
+	v_accvgpr_read_b32 v217, a161                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a162                              
+	v_accvgpr_read_b32 v219, a163                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v243, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a192                              
+	v_accvgpr_read_b32 v213, a193                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a194                              
+	v_accvgpr_read_b32 v215, a195                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a224                              
+	v_accvgpr_read_b32 v217, a225                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a226                              
+	v_accvgpr_read_b32 v219, a227                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v243, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[76:79], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[108:111], a[132:135], v208, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[140:143], v[76:79], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[156:159], v[108:111], a[164:167], v208, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[76:79], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[108:111], a[196:199], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[148:151], v[76:79], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[164:167], v[108:111], a[228:231], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a132                              
+	v_accvgpr_read_b32 v213, a133                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a134                              
+	v_accvgpr_read_b32 v215, a135                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a164                              
+	v_accvgpr_read_b32 v217, a165                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a166                              
+	v_accvgpr_read_b32 v219, a167                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v244, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a196                              
+	v_accvgpr_read_b32 v213, a197                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a198                              
+	v_accvgpr_read_b32 v215, a199                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a228                              
+	v_accvgpr_read_b32 v217, a229                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a230                              
+	v_accvgpr_read_b32 v219, a231                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v244, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[136:139], v[80:83], a[136:139], v208, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[152:155], v[112:115], a[136:139], v208, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[80:83], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[156:159], v[112:115], a[168:171], v208, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[144:147], v[80:83], a[200:203], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[160:163], v[112:115], a[200:203], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[148:151], v[80:83], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[164:167], v[112:115], a[232:235], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a136                              
+	v_accvgpr_read_b32 v213, a137                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a138                              
+	v_accvgpr_read_b32 v215, a139                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a168                              
+	v_accvgpr_read_b32 v217, a169                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a170                              
+	v_accvgpr_read_b32 v219, a171                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v245, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a200                              
+	v_accvgpr_read_b32 v213, a201                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a202                              
+	v_accvgpr_read_b32 v215, a203                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a232                              
+	v_accvgpr_read_b32 v217, a233                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a234                              
+	v_accvgpr_read_b32 v219, a235                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v245, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[136:139], v[84:87], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[152:155], v[116:119], a[140:143], v208, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[84:87], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[156:159], v[116:119], a[172:175], v208, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[144:147], v[84:87], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[160:163], v[116:119], a[204:207], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[148:151], v[84:87], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[164:167], v[116:119], a[236:239], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a140                              
+	v_accvgpr_read_b32 v213, a141                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a142                              
+	v_accvgpr_read_b32 v215, a143                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a172                              
+	v_accvgpr_read_b32 v217, a173                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a174                              
+	v_accvgpr_read_b32 v219, a175                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v246, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a204                              
+	v_accvgpr_read_b32 v213, a205                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a206                              
+	v_accvgpr_read_b32 v215, a207                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a236                              
+	v_accvgpr_read_b32 v217, a237                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a238                              
+	v_accvgpr_read_b32 v219, a239                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v246, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[88:91], a[144:147], v208, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[152:155], v[120:123], a[144:147], v208, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[140:143], v[88:91], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[156:159], v[120:123], a[176:179], v208, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[144:147], v[88:91], a[208:211], v209, v206 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[120:123], a[208:211], v209, v206 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[148:151], v[88:91], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[164:167], v[120:123], a[240:243], v209, v206 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a144                              
+	v_accvgpr_read_b32 v213, a145                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a146                              
+	v_accvgpr_read_b32 v215, a147                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a176                              
+	v_accvgpr_read_b32 v217, a177                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a178                              
+	v_accvgpr_read_b32 v219, a179                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v247, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a208                              
+	v_accvgpr_read_b32 v213, a209                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a210                              
+	v_accvgpr_read_b32 v215, a211                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a240                              
+	v_accvgpr_read_b32 v217, a241                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a242                              
+	v_accvgpr_read_b32 v219, a243                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v247, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[92:95], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[152:155], v[124:127], a[148:151], v208, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[140:143], v[92:95], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[156:159], v[124:127], a[180:183], v208, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[144:147], v[92:95], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[124:127], a[212:215], v209, v206 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[148:151], v[92:95], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[164:167], v[124:127], a[244:247], v209, v206 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a148                              
+	v_accvgpr_read_b32 v213, a149                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a150                              
+	v_accvgpr_read_b32 v215, a151                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a180                              
+	v_accvgpr_read_b32 v217, a181                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a182                              
+	v_accvgpr_read_b32 v219, a183                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v248, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a212                              
+	v_accvgpr_read_b32 v213, a213                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a214                              
+	v_accvgpr_read_b32 v215, a215                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a244                              
+	v_accvgpr_read_b32 v217, a245                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a246                              
+	v_accvgpr_read_b32 v219, a247                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v248, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[136:139], v[96:99], a[152:155], v208, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[152:155], v[128:131], a[152:155], v208, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[96:99], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[128:131], a[184:187], v208, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[144:147], v[96:99], a[216:219], v209, v207 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[160:163], v[128:131], a[216:219], v209, v207 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[148:151], v[96:99], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[164:167], v[128:131], a[248:251], v209, v207 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a152                              
+	v_accvgpr_read_b32 v213, a153                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a154                              
+	v_accvgpr_read_b32 v215, a155                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a184                              
+	v_accvgpr_read_b32 v217, a185                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a186                              
+	v_accvgpr_read_b32 v219, a187                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v249, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a216                              
+	v_accvgpr_read_b32 v213, a217                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a218                              
+	v_accvgpr_read_b32 v215, a219                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a248                              
+	v_accvgpr_read_b32 v217, a249                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a250                              
+	v_accvgpr_read_b32 v219, a251                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v249, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[136:139], v[100:103], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[152:155], v[132:135], a[156:159], v208, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[100:103], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[132:135], a[188:191], v208, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[144:147], v[100:103], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[160:163], v[132:135], a[220:223], v209, v207 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[148:151], v[100:103], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[164:167], v[132:135], a[252:255], v209, v207 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_mov_b32 s46, s55                                         
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a156                              
+	v_accvgpr_read_b32 v213, a157                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a158                              
+	v_accvgpr_read_b32 v215, a159                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a188                              
+	v_accvgpr_read_b32 v217, a189                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a190                              
+	v_accvgpr_read_b32 v219, a191                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v250, 0                                  
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_cmp_lt_i32 s46, s40                                      
+	s_cselect_b32 s74, -1, 0                                   
+	s_cselect_b32 s75, -1, 0                                   
+	s_and_saveexec_b64 s[72:73], s[74:75]                      
+	v_accvgpr_read_b32 v212, a220                              
+	v_accvgpr_read_b32 v213, a221                              
+	v_pk_mul_f32 v[212:213], s[32:33], v[212:213]              
+	v_accvgpr_read_b32 v214, a222                              
+	v_accvgpr_read_b32 v215, a223                              
+	v_pk_mul_f32 v[214:215], s[32:33], v[214:215]              
+	v_accvgpr_read_b32 v216, a252                              
+	v_accvgpr_read_b32 v217, a253                              
+	v_pk_mul_f32 v[216:217], s[32:33], v[216:217]              
+	v_accvgpr_read_b32 v218, a254                              
+	v_accvgpr_read_b32 v219, a255                              
+	v_pk_mul_f32 v[218:219], s[32:33], v[218:219]              
+	v_cvt_pk_bf16_f32 v226, v212, v213                         
+	v_cvt_pk_bf16_f32 v227, v214, v215                         
+	v_cvt_pk_bf16_f32 v228, v216, v217                         
+	v_cvt_pk_bf16_f32 v229, v218, v219                         
+	s_nop 1                                                    
+	.long 0x7fc4b3e4                                           
+	s_nop 1                                                    
+	.long 0x7fc6b3e5                                           
+	s_nop 1                                                    
+	v_add_u32_e64 v4, v250, 64                                 
+	buffer_store_dwordx4 v[226:229], v4, s[4:7], 0 offen       
+	s_mov_b64 exec, s[72:73]                                   
+	s_addk_i32 s46, 0x20                                       
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2292,7 +2292,7 @@ label_12E9:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2739,14 +2739,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA.s
@@ -1,0 +1,2757 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x3ff                                  
+	s_lshr_b32 s50, s51, 10                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v213, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v213, v5, v213                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v213, v6, v213                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v213, v4, v213                               
+	v_add_u32_e32 v213, 0x1000, v213                           
+	v_add_u32_e32 v214, 0x1080, v213                           
+	v_add_u32_e32 v215, 0x1080, v214                           
+	v_add_u32_e32 v216, 0x1080, v215                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v217, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v217, s63, v217                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v218, 2, v0                              
+	v_add_u32_e32 v218, 0, v218                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v219, 4, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v219, s62, v219                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	v_add_u32_e32 v225, s62, v224                              
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	v_add_u32_e32 v228, s62, v227                              
+	v_add_u32_e32 v229, s62, v228                              
+	v_add_u32_e32 v230, s62, v229                              
+	v_add_u32_e32 v231, s62, v230                              
+	v_add_u32_e32 v232, s62, v231                              
+	v_add_u32_e32 v233, s62, v232                              
+	v_add_u32_e32 v234, s62, v233                              
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v235, 2, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v235, s63, v235                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v236, s62, v235                              
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	v_add_u32_e32 v240, s62, v239                              
+	v_add_u32_e32 v241, s62, v240                              
+	v_add_u32_e32 v242, s62, v241                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v213                                 
+	ds_read_b128 v[16:19], v213 offset:64                      
+	ds_read_b128 v[12:15], v213 offset:512                     
+	ds_read_b128 v[20:23], v213 offset:576                     
+	ds_read_b32 v200, v218                                     
+	ds_read_b128 v[24:27], v214                                
+	ds_read_b128 v[32:35], v214 offset:64                      
+	ds_read_b128 v[28:31], v214 offset:512                     
+	ds_read_b128 v[36:39], v214 offset:576                     
+	ds_read_b32 v201, v218 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x400                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x100                                  
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v243, s36, v5                                 
+	v_add_u32_e32 v243, s62, v243                              
+	v_add_u32_e32 v243, v4, v243                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0899                                  
+	
+label_028A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v202, v218 offset:2048                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[24:27], a[112:115], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[28:31], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[24:27], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[28:31], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[32:35], a[112:115], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[36:39], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v203, v218 offset:3072                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v213                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v213 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v213 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v213 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v200, v218                                     
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[56:59], a[112:115], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v214                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[60:63], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[56:59], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[60:63], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[64:67], a[112:115], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[68:71], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v201, v218 offset:1024                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_branch label_028A                                        
+	
+label_0899:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	ds_read_b32 v202, v218 offset:2048                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[24:27], a[112:115], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[28:31], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[24:27], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[28:31], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[32:35], a[112:115], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[36:39], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:576                     
+	ds_read_b32 v203, v218 offset:3072                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v213                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v213 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v213 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v213 offset:576                     
+	ds_read_b32 v200, v218                                     
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[56:59], a[112:115], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[60:63], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v214                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[56:59], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[60:63], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[64:67], a[112:115], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[68:71], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:576                     
+	ds_read_b32 v201, v218 offset:1024                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0EA8                                  
+	s_branch label_0899                                        
+	
+label_0EA8:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_i32 s63, s46, 0x100                                  
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x100                                  
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_10C2                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v247, 0, v243                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 64, v243                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x80, v243                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0xc0, v243                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x100, v243                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x140, v243                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x180, v243                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x1c0, v243                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_branch label_12E9                                        
+	
+label_10C2:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0, v243                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 64, v243                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x80, v243                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0xc0, v243                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x100, v243                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x140, v243                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x180, v243                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x1c0, v243                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	
+label_12E9:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB.s
@@ -1,0 +1,2757 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x3ff                                  
+	s_lshr_b32 s50, s51, 10                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v213, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v213, v5, v213                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v213, v6, v213                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v213, v4, v213                               
+	v_add_u32_e32 v213, 0x1000, v213                           
+	v_add_u32_e32 v214, 0x1080, v213                           
+	v_add_u32_e32 v215, 0x1080, v214                           
+	v_add_u32_e32 v216, 0x1080, v215                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v217, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v217, s63, v217                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v218, 2, v0                              
+	v_add_u32_e32 v218, 0, v218                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v219, 4, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v219, s62, v219                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	v_add_u32_e32 v225, s62, v224                              
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	v_add_u32_e32 v228, s62, v227                              
+	v_add_u32_e32 v229, s62, v228                              
+	v_add_u32_e32 v230, s62, v229                              
+	v_add_u32_e32 v231, s62, v230                              
+	v_add_u32_e32 v232, s62, v231                              
+	v_add_u32_e32 v233, s62, v232                              
+	v_add_u32_e32 v234, s62, v233                              
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v235, 2, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v235, s63, v235                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v236, s62, v235                              
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	v_add_u32_e32 v240, s62, v239                              
+	v_add_u32_e32 v241, s62, v240                              
+	v_add_u32_e32 v242, s62, v241                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v213                                 
+	ds_read_b128 v[16:19], v213 offset:64                      
+	ds_read_b128 v[12:15], v213 offset:512                     
+	ds_read_b128 v[20:23], v213 offset:576                     
+	ds_read_b32 v200, v218                                     
+	ds_read_b128 v[24:27], v214                                
+	ds_read_b128 v[32:35], v214 offset:64                      
+	ds_read_b128 v[28:31], v214 offset:512                     
+	ds_read_b128 v[36:39], v214 offset:576                     
+	ds_read_b32 v201, v218 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x400                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x100                                  
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v243, s36, v5                                 
+	v_add_u32_e32 v243, s62, v243                              
+	v_add_u32_e32 v243, v4, v243                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0899                                  
+	
+label_028A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v202, v218 offset:2048                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[24:27], a[112:115], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[28:31], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[24:27], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[28:31], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[32:35], a[112:115], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[36:39], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v203, v218 offset:3072                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v213                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v213 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v213 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v213 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v200, v218                                     
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[56:59], a[112:115], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v214                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[60:63], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[56:59], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[60:63], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[64:67], a[112:115], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[68:71], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	ds_read_b32 v201, v218 offset:1024                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_branch label_028A                                        
+	
+label_0899:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	ds_read_b32 v202, v218 offset:2048                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[24:27], a[112:115], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[28:31], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[24:27], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[28:31], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[32:35], a[112:115], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[36:39], a[116:119], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[32:35], a[120:123], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[36:39], a[124:127], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:576                     
+	ds_read_b32 v203, v218 offset:3072                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v213                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v213 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v213 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v213 offset:576                     
+	ds_read_b32 v200, v218                                     
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v238, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v239, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v240, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v241, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v234, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v234, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v242, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v220, s[16:19], 0 offen offset:1024
+	buffer_load_dword v204, v235, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v222, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v236, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[56:59], a[112:115], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[60:63], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v214                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[56:59], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[60:63], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[64:67], a[112:115], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[68:71], a[116:119], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[64:67], a[120:123], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[68:71], a[124:127], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:576                     
+	ds_read_b32 v201, v218 offset:1024                         
+	buffer_load_dword v206, v237, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0EA8                                  
+	s_branch label_0899                                        
+	
+label_0EA8:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_i32 s63, s46, 0x100                                  
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x100                                  
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_10C2                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v247, 0, v243                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 64, v243                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x80, v243                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0xc0, v243                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x100, v243                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x140, v243                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x180, v243                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_add_u32_e32 v247, 0x1c0, v243                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_branch label_12E9                                        
+	
+label_10C2:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0, v243                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 64, v243                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x80, v243                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0xc0, v243                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x100, v243                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x140, v243                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x180, v243                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_12E9                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v247, 0x1c0, v243                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v247, s[4:7], 0 offen       
+	v_add_u32_e32 v247, s62, v247                              
+	
+label_12E9:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x1024_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -865,7 +865,7 @@ label_051E:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1312,14 +1312,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA.s
@@ -1,0 +1,1330 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v145, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v145, v5, v145                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v145, v6, v145                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v145, v4, v145                               
+	v_add_u32_e32 v145, 0x1000, v145                           
+	v_add_u32_e32 v146, 0x1080, v145                           
+	v_add_u32_e32 v147, 0x1080, v146                           
+	v_add_u32_e32 v148, 0x1080, v147                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v149, s63, v149                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	v_add_u32_e32 v150, 0, v150                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v151, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v151, s62, v151                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v152, s62, v151                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v153, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v153, s63, v153                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v153, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[88:91], v151, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[92:95], v152, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[96:99], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v153, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v153, s[24:27], 0 offen            
+	s_add_u32 s62, 0x400, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v145                                 
+	ds_read_b128 v[16:19], v145 offset:64                      
+	ds_read_b128 v[12:15], v145 offset:512                     
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	ds_read_b128 v[24:27], v146                                
+	ds_read_b128 v[32:35], v146 offset:64                      
+	ds_read_b128 v[28:31], v146 offset:512                     
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v154, s36, v5                                 
+	v_add_u32_e32 v154, s62, v154                              
+	v_add_u32_e32 v154, v4, v154                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0333                                  
+	
+label_01D8:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v152, s[16:19], 0 offen    
+	ds_read_b32 v138, v150 offset:2048                         
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[24:27], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[28:31], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[32:35], a[0:3], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[36:39], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[32:35], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[68:71], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[36:39], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	ds_read_b32 v139, v150 offset:3072                         
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v145 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v152, s[16:19], 0 offen      
+	ds_read_b32 v136, v150                                     
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[36:39], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	ds_read_b32 v137, v150 offset:1024                         
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_branch label_01D8                                        
+	
+label_0333:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v150 offset:2048                         
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[24:27], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[28:31], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[32:35], a[0:3], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[36:39], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[32:35], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[36:39], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[68:71], v148 offset:576                     
+	ds_read_b32 v139, v150 offset:3072                         
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v153, s[24:27], 0 offen            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_branch label_0333                                        
+	
+label_048E:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_04D9                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v158, 0, v154                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	s_branch label_051E                                        
+	
+label_04D9:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_051E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v158, 0, v154                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	
+label_051E:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB.s
@@ -1,0 +1,1330 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v145, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v145, v5, v145                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v145, v6, v145                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v145, v4, v145                               
+	v_add_u32_e32 v145, 0x1000, v145                           
+	v_add_u32_e32 v146, 0x1080, v145                           
+	v_add_u32_e32 v147, 0x1080, v146                           
+	v_add_u32_e32 v148, 0x1080, v147                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v149, s63, v149                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	v_add_u32_e32 v150, 0, v150                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v151, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v151, s62, v151                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v152, s62, v151                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v153, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v153, s63, v153                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v153, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[88:91], v151, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[92:95], v152, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[96:99], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v153, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v153, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x400, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(19)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v145                                 
+	ds_read_b128 v[16:19], v145 offset:64                      
+	ds_read_b128 v[12:15], v145 offset:512                     
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	ds_read_b128 v[24:27], v146                                
+	ds_read_b128 v[32:35], v146 offset:64                      
+	ds_read_b128 v[28:31], v146 offset:512                     
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v154, s36, v5                                 
+	v_add_u32_e32 v154, s62, v154                              
+	v_add_u32_e32 v154, v4, v154                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0333                                  
+	
+label_01D8:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v152, s[16:19], 0 offen nt    
+	ds_read_b32 v138, v150 offset:2048                         
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[24:27], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[28:31], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[32:35], a[0:3], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[36:39], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[32:35], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[68:71], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[36:39], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	ds_read_b32 v139, v150 offset:3072                         
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v145 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v152, s[16:19], 0 offen nt      
+	ds_read_b32 v136, v150                                     
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[36:39], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	ds_read_b32 v137, v150 offset:1024                         
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_branch label_01D8                                        
+	
+label_0333:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v150 offset:2048                         
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[24:27], a[0:3], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[28:31], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[24:27], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[28:31], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[32:35], a[0:3], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[36:39], a[4:7], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[32:35], a[8:11], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[36:39], a[12:15], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[68:71], v148 offset:576                     
+	ds_read_b32 v139, v150 offset:3072                         
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x500, s60                                  
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v153, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_048E                                  
+	s_branch label_0333                                        
+	
+label_048E:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_04D9                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v158, 0, v154                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	s_branch label_051E                                        
+	
+label_04D9:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_051E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v158, 0, v154                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v158, s[4:7], 0 offen       
+	v_add_u32_e32 v158, s62, v158                              
+	
+label_051E:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1044,7 +1044,7 @@ label_06F6:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1491,14 +1491,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA.s
@@ -1,0 +1,1509 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v145, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v145, v5, v145                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v145, v6, v145                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v145, v4, v145                               
+	v_add_u32_e32 v145, 0x1000, v145                           
+	v_add_u32_e32 v146, 0x1080, v145                           
+	v_add_u32_e32 v147, 0x1080, v146                           
+	v_add_u32_e32 v148, 0x1080, v147                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v149, s63, v149                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	v_add_u32_e32 v150, 0, v150                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v151, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v151, s62, v151                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v152, s62, v151                              
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v155, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v155, s63, v155                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v156, s62, v155                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v155, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v155, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v145                                 
+	ds_read_b128 v[16:19], v145 offset:64                      
+	ds_read_b128 v[12:15], v145 offset:512                     
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	ds_read_b128 v[24:27], v146                                
+	ds_read_b128 v[32:35], v146 offset:64                      
+	ds_read_b128 v[28:31], v146 offset:512                     
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v157, s36, v5                                 
+	v_add_u32_e32 v157, s62, v157                              
+	v_add_u32_e32 v157, v4, v157                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_03DA                                  
+	
+label_01D3:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v138, v150 offset:2048                         
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[24:27], a[0:3], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[28:31], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[24:27], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[28:31], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[32:35], a[0:3], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[36:39], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[32:35], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[36:39], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[68:71], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v139, v150 offset:3072                         
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v145 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v136, v150                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[36:39], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v137, v150 offset:1024                         
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_branch label_01D3                                        
+	
+label_03DA:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v150 offset:2048                         
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[24:27], a[0:3], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[28:31], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[24:27], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[28:31], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[32:35], a[0:3], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[36:39], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[32:35], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[36:39], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[68:71], v148 offset:576                     
+	ds_read_b32 v139, v150 offset:3072                         
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_branch label_03DA                                        
+	
+label_05E1:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_066D                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_add_u32_e32 v161, 64, v157                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	s_branch label_06F6                                        
+	
+label_066D:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_06F6                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_06F6                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v161, 64, v157                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	
+label_06F6:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB.s
@@ -1,0 +1,1509 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v145, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v145, v5, v145                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v145, v6, v145                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v145, v4, v145                               
+	v_add_u32_e32 v145, 0x1000, v145                           
+	v_add_u32_e32 v146, 0x1080, v145                           
+	v_add_u32_e32 v147, 0x1080, v146                           
+	v_add_u32_e32 v148, 0x1080, v147                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v149, s63, v149                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	v_add_u32_e32 v150, 0, v150                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v151, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v151, s62, v151                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v152, s62, v151                              
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v155, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v155, s63, v155                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v156, s62, v155                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v155, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v155, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v145                                 
+	ds_read_b128 v[16:19], v145 offset:64                      
+	ds_read_b128 v[12:15], v145 offset:512                     
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	ds_read_b128 v[24:27], v146                                
+	ds_read_b128 v[32:35], v146 offset:64                      
+	ds_read_b128 v[28:31], v146 offset:512                     
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v157, s36, v5                                 
+	v_add_u32_e32 v157, s62, v157                              
+	v_add_u32_e32 v157, v4, v157                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_03DA                                  
+	
+label_01D3:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v138, v150 offset:2048                         
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[24:27], a[0:3], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[28:31], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[24:27], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[28:31], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[32:35], a[0:3], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[36:39], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[32:35], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[36:39], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[68:71], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v139, v150 offset:3072                         
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v145 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v136, v150                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[36:39], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	ds_read_b32 v137, v150 offset:1024                         
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_branch label_01D3                                        
+	
+label_03DA:
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v150 offset:2048                         
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[24:27], a[0:3], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[28:31], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[24:27], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[28:31], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[32:35], a[0:3], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[36:39], a[4:7], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[32:35], a[8:11], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[36:39], a[12:15], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[24:27], a[16:19], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[28:31], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[24:27], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[28:31], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[32:35], a[16:19], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[36:39], a[20:23], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[32:35], a[24:27], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[36:39], a[28:31], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[68:71], v148 offset:576                     
+	ds_read_b32 v139, v150 offset:3072                         
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_waitcnt vmcnt(12) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v156, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v151, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v152, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v155, s[24:27], 0 offen nt            
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_05E1                                  
+	s_branch label_03DA                                        
+	
+label_05E1:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_066D                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_add_u32_e32 v161, 64, v157                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	s_branch label_06F6                                        
+	
+label_066D:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_06F6                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v161, 0, v157                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_06F6                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v161, 64, v157                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v161, s[4:7], 0 offen       
+	v_add_u32_e32 v161, s62, v161                              
+	
+label_06F6:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1267,7 +1267,7 @@ label_0909:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1714,14 +1714,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA.s
@@ -1,0 +1,1732 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v179, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v179, v5, v179                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v179, v6, v179                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v179, v4, v179                               
+	v_add_u32_e32 v179, 0x1000, v179                           
+	v_add_u32_e32 v180, 0x1080, v179                           
+	v_add_u32_e32 v181, 0x1080, v180                           
+	v_add_u32_e32 v182, 0x1080, v181                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v183, s63, v183                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	v_add_u32_e32 v184, 0, v184                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v185, s62, v185                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v191, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v191, s63, v191                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v192, s62, v191                              
+	v_add_u32_e32 v193, s62, v192                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v172, v191, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v192, s[24:27], 0 offen            
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v179                                 
+	ds_read_b128 v[16:19], v179 offset:64                      
+	ds_read_b128 v[12:15], v179 offset:512                     
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	ds_read_b128 v[24:27], v180                                
+	ds_read_b128 v[32:35], v180 offset:64                      
+	ds_read_b128 v[28:31], v180 offset:512                     
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v194, s36, v5                                 
+	v_add_u32_e32 v194, s62, v194                              
+	v_add_u32_e32 v194, v4, v194                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_04B8                                  
+	
+label_0205:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen    
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v177, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[24:27], a[0:3], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[28:31], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[24:27], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[28:31], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[32:35], a[0:3], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[36:39], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[32:35], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[36:39], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen    
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v177, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[56:59], a[16:19], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[60:63], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[56:59], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[60:63], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[64:67], a[16:19], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[68:71], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[64:67], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[68:71], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[56:59], a[32:35], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[60:63], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[56:59], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[60:63], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[64:67], a[32:35], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[68:71], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[64:67], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[68:71], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_branch label_0205                                        
+	
+label_04B8:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v177, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[24:27], a[0:3], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[28:31], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[24:27], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[28:31], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[32:35], a[0:3], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[36:39], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[32:35], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[36:39], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v177, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[56:59], a[16:19], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[60:63], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[56:59], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[60:63], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[64:67], a[16:19], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[68:71], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[64:67], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[68:71], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v192, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[56:59], a[32:35], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[60:63], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[56:59], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[60:63], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[64:67], a[32:35], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[68:71], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[64:67], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[68:71], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_branch label_04B8                                        
+	
+label_076B:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_083B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_add_u32_e32 v198, 64, v194                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_add_u32_e32 v198, 0x80, v194                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_branch label_0909                                        
+	
+label_083B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0909                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0909                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 64, v194                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0909                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 0x80, v194                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	
+label_0909:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB.s
@@ -1,0 +1,1732 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v179, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v179, v5, v179                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v179, v6, v179                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v179, v4, v179                               
+	v_add_u32_e32 v179, 0x1000, v179                           
+	v_add_u32_e32 v180, 0x1080, v179                           
+	v_add_u32_e32 v181, 0x1080, v180                           
+	v_add_u32_e32 v182, 0x1080, v181                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v183, s63, v183                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	v_add_u32_e32 v184, 0, v184                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v185, s62, v185                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v191, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v191, s63, v191                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v192, s62, v191                              
+	v_add_u32_e32 v193, s62, v192                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v172, v191, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v192, s[24:27], 0 offen nt            
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v179                                 
+	ds_read_b128 v[16:19], v179 offset:64                      
+	ds_read_b128 v[12:15], v179 offset:512                     
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	ds_read_b128 v[24:27], v180                                
+	ds_read_b128 v[32:35], v180 offset:64                      
+	ds_read_b128 v[28:31], v180 offset:512                     
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v194, s36, v5                                 
+	v_add_u32_e32 v194, s62, v194                              
+	v_add_u32_e32 v194, v4, v194                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_04B8                                  
+	
+label_0205:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen nt    
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v177, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[24:27], a[0:3], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[28:31], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[24:27], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[28:31], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[32:35], a[0:3], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[36:39], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[32:35], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[36:39], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen nt    
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v177, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[56:59], a[16:19], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[60:63], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[56:59], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[60:63], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[64:67], a[16:19], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[68:71], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[64:67], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[68:71], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[56:59], a[32:35], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[60:63], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[56:59], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[60:63], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[64:67], a[32:35], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[68:71], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[64:67], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[68:71], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_branch label_0205                                        
+	
+label_04B8:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v177, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[24:27], a[0:3], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[28:31], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[24:27], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[28:31], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[32:35], a[0:3], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[36:39], a[4:7], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[32:35], a[8:11], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[36:39], a[12:15], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[24:27], a[32:35], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[28:31], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[24:27], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[28:31], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[32:35], a[32:35], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[36:39], a[36:39], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[32:35], a[40:43], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[36:39], a[44:47], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[132:135], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v177, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v191, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[56:59], a[16:19], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[60:63], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[56:59], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[60:63], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[64:67], a[16:19], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[68:71], a[20:23], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[64:67], a[24:27], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[68:71], a[28:31], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v192, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[56:59], a[32:35], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[60:63], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[56:59], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[60:63], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[64:67], a[32:35], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[68:71], a[36:39], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[64:67], a[40:43], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[68:71], a[44:47], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_076B                                  
+	s_branch label_04B8                                        
+	
+label_076B:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_083B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_add_u32_e32 v198, 64, v194                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_add_u32_e32 v198, 0x80, v194                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_branch label_0909                                        
+	
+label_083B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0909                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 0, v194                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0909                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 64, v194                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0909                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v198, 0x80, v194                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v198, s[4:7], 0 offen       
+	v_add_u32_e32 v198, s62, v198                              
+	
+label_0909:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x384_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1444,7 +1444,7 @@ label_0AE1:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1891,14 +1891,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA.s
@@ -1,0 +1,1909 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x1ff                                  
+	s_lshr_b32 s50, s51, 9                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v145, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v145, v5, v145                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v145, v6, v145                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v145, v4, v145                               
+	v_add_u32_e32 v145, 0x1000, v145                           
+	v_add_u32_e32 v146, 0x1080, v145                           
+	v_add_u32_e32 v147, 0x1080, v146                           
+	v_add_u32_e32 v148, 0x1080, v147                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v149, s63, v149                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	v_add_u32_e32 v150, 0, v150                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v151, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v151, s62, v151                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v152, s62, v151                              
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	v_add_u32_e32 v155, s62, v154                              
+	v_add_u32_e32 v156, s62, v155                              
+	v_add_u32_e32 v157, s62, v156                              
+	v_add_u32_e32 v158, s62, v157                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v159, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v159, s63, v159                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v160, s62, v159                              
+	v_add_u32_e32 v161, s62, v160                              
+	v_add_u32_e32 v162, s62, v161                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v145                                 
+	ds_read_b128 v[16:19], v145 offset:64                      
+	ds_read_b128 v[12:15], v145 offset:512                     
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	ds_read_b128 v[24:27], v146                                
+	ds_read_b128 v[32:35], v146 offset:64                      
+	ds_read_b128 v[28:31], v146 offset:512                     
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x80                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v163, s36, v5                                 
+	v_add_u32_e32 v163, s62, v163                              
+	v_add_u32_e32 v163, v4, v163                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_055D                                  
+	
+label_01FE:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v138, v150 offset:2048                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v139, v150 offset:3072                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v145 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v136, v150                                     
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v137, v150 offset:1024                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_branch label_01FE                                        
+	
+label_055D:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v150 offset:2048                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:576                     
+	ds_read_b32 v139, v150 offset:3072                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen            
+	s_cbranch_scc0 label_08BC                                  
+	s_branch label_055D                                        
+	
+label_08BC:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_i32 s63, s46, 0x80                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x80                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_09CE                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v167, 0, v163                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_add_u32_e32 v167, 64, v163                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_add_u32_e32 v167, 0x80, v163                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_add_u32_e32 v167, 0xc0, v163                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_branch label_0AE1                                        
+	
+label_09CE:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 0, v163                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 64, v163                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 0x80, v163                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 0xc0, v163                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	
+label_0AE1:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB.s
@@ -1,0 +1,1909 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x1ff                                  
+	s_lshr_b32 s50, s51, 9                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v145, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v145, v5, v145                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v145, v6, v145                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v145, v4, v145                               
+	v_add_u32_e32 v145, 0x1000, v145                           
+	v_add_u32_e32 v146, 0x1080, v145                           
+	v_add_u32_e32 v147, 0x1080, v146                           
+	v_add_u32_e32 v148, 0x1080, v147                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v149, s63, v149                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	v_add_u32_e32 v150, 0, v150                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v151, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v151, s62, v151                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v152, s62, v151                              
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	v_add_u32_e32 v155, s62, v154                              
+	v_add_u32_e32 v156, s62, v155                              
+	v_add_u32_e32 v157, s62, v156                              
+	v_add_u32_e32 v158, s62, v157                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v159, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v159, s63, v159                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v160, s62, v159                              
+	v_add_u32_e32 v161, s62, v160                              
+	v_add_u32_e32 v162, s62, v161                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v145                                 
+	ds_read_b128 v[16:19], v145 offset:64                      
+	ds_read_b128 v[12:15], v145 offset:512                     
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	ds_read_b128 v[24:27], v146                                
+	ds_read_b128 v[32:35], v146 offset:64                      
+	ds_read_b128 v[28:31], v146 offset:512                     
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x80                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v163, s36, v5                                 
+	v_add_u32_e32 v163, s62, v163                              
+	v_add_u32_e32 v163, v4, v163                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_055D                                  
+	
+label_01FE:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v138, v150 offset:2048                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v139, v150 offset:3072                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v145 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v136, v150                                     
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	ds_read_b32 v137, v150 offset:1024                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_branch label_01FE                                        
+	
+label_055D:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v150 offset:2048                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v148                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v148 offset:576                     
+	ds_read_b32 v139, v150 offset:3072                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v145                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v145 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v145 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v145 offset:576                     
+	ds_read_b32 v136, v150                                     
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v158, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v158, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v162, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v149, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v159, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v160, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v146                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:576                     
+	ds_read_b32 v137, v150 offset:1024                         
+	buffer_load_dword v142, v161, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_08BC                                  
+	s_branch label_055D                                        
+	
+label_08BC:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_i32 s63, s46, 0x80                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x80                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_09CE                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v167, 0, v163                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_add_u32_e32 v167, 64, v163                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_add_u32_e32 v167, 0x80, v163                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_add_u32_e32 v167, 0xc0, v163                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_branch label_0AE1                                        
+	
+label_09CE:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 0, v163                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 64, v163                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 0x80, v163                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AE1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v167, 0xc0, v163                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v167, s[4:7], 0 offen       
+	v_add_u32_e32 v167, s62, v167                              
+	
+label_0AE1:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x512_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1681,7 +1681,7 @@ label_0D02:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2128,14 +2128,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA.s
@@ -1,0 +1,2146 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x27f                                  
+	s_mov_b32 s63, 0x280                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v162, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v162, v5, v162                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v162, v6, v162                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v162, v4, v162                               
+	v_add_u32_e32 v162, 0x1000, v162                           
+	v_add_u32_e32 v163, 0x1080, v162                           
+	v_add_u32_e32 v164, 0x1080, v163                           
+	v_add_u32_e32 v165, 0x1080, v164                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v166, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v166, s63, v166                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v167, 2, v0                              
+	v_add_u32_e32 v167, 0, v167                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v168, 4, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v168, s62, v168                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v169, s62, v168                              
+	v_add_u32_e32 v170, s62, v169                              
+	v_add_u32_e32 v171, s62, v170                              
+	v_add_u32_e32 v172, s62, v171                              
+	v_add_u32_e32 v173, s62, v172                              
+	v_add_u32_e32 v174, s62, v173                              
+	v_add_u32_e32 v175, s62, v174                              
+	v_add_u32_e32 v176, s62, v175                              
+	v_add_u32_e32 v177, s62, v176                              
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v178, 2, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v178, s63, v178                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	v_add_u32_e32 v182, s62, v181                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v162                                 
+	ds_read_b128 v[16:19], v162 offset:64                      
+	ds_read_b128 v[12:15], v162 offset:512                     
+	ds_read_b128 v[20:23], v162 offset:576                     
+	ds_read_b32 v152, v167                                     
+	ds_read_b128 v[24:27], v163                                
+	ds_read_b128 v[32:35], v163 offset:64                      
+	ds_read_b128 v[28:31], v163 offset:512                     
+	ds_read_b128 v[36:39], v163 offset:576                     
+	ds_read_b32 v153, v167 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x280                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xa0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v183, s36, v5                                 
+	v_add_u32_e32 v183, s62, v183                              
+	v_add_u32_e32 v183, v4, v183                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_064B                                  
+	
+label_0240:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v154, v167 offset:2048                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v165                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v165 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v165 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v165 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v155, v167 offset:3072                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v162                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v162 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v162 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v162 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v152, v167                                     
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v163                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v153, v167 offset:1024                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_branch label_0240                                        
+	
+label_064B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	ds_read_b32 v154, v167 offset:2048                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v165                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v165 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v165 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v165 offset:576                     
+	ds_read_b32 v155, v167 offset:3072                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v162                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v162 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v162 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v162 offset:576                     
+	ds_read_b32 v152, v167                                     
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v163                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:576                     
+	ds_read_b32 v153, v167 offset:1024                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0A56                                  
+	s_branch label_064B                                        
+	
+label_0A56:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xa0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0BAA                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v187, 0, v183                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 64, v183                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 0x80, v183                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 0xc0, v183                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 0x100, v183                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_branch label_0D02                                        
+	
+label_0BAA:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0, v183                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 64, v183                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0x80, v183                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0xc0, v183                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0x100, v183                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	
+label_0D02:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB.s
@@ -1,0 +1,2146 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x27f                                  
+	s_mov_b32 s63, 0x280                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v162, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v162, v5, v162                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v162, v6, v162                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v162, v4, v162                               
+	v_add_u32_e32 v162, 0x1000, v162                           
+	v_add_u32_e32 v163, 0x1080, v162                           
+	v_add_u32_e32 v164, 0x1080, v163                           
+	v_add_u32_e32 v165, 0x1080, v164                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v166, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v166, s63, v166                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v167, 2, v0                              
+	v_add_u32_e32 v167, 0, v167                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v168, 4, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v168, s62, v168                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v169, s62, v168                              
+	v_add_u32_e32 v170, s62, v169                              
+	v_add_u32_e32 v171, s62, v170                              
+	v_add_u32_e32 v172, s62, v171                              
+	v_add_u32_e32 v173, s62, v172                              
+	v_add_u32_e32 v174, s62, v173                              
+	v_add_u32_e32 v175, s62, v174                              
+	v_add_u32_e32 v176, s62, v175                              
+	v_add_u32_e32 v177, s62, v176                              
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v178, 2, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v178, s63, v178                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	v_add_u32_e32 v182, s62, v181                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v162                                 
+	ds_read_b128 v[16:19], v162 offset:64                      
+	ds_read_b128 v[12:15], v162 offset:512                     
+	ds_read_b128 v[20:23], v162 offset:576                     
+	ds_read_b32 v152, v167                                     
+	ds_read_b128 v[24:27], v163                                
+	ds_read_b128 v[32:35], v163 offset:64                      
+	ds_read_b128 v[28:31], v163 offset:512                     
+	ds_read_b128 v[36:39], v163 offset:576                     
+	ds_read_b32 v153, v167 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x280                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xa0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v183, s36, v5                                 
+	v_add_u32_e32 v183, s62, v183                              
+	v_add_u32_e32 v183, v4, v183                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_064B                                  
+	
+label_0240:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v154, v167 offset:2048                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v165                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v165 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v165 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v165 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v155, v167 offset:3072                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v162                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v162 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v162 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v162 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v152, v167                                     
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v163                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	ds_read_b32 v153, v167 offset:1024                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_branch label_0240                                        
+	
+label_064B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	ds_read_b32 v154, v167 offset:2048                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v165                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v165 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v165 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v165 offset:576                     
+	ds_read_b32 v155, v167 offset:3072                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v162                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v162 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v162 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v162 offset:576                     
+	ds_read_b32 v152, v167                                     
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v181, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v177, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v177, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v182, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v166, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v169, s[16:19], 0 offen offset:1024
+	buffer_load_dword v156, v178, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v171, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v179, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v163                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:576                     
+	ds_read_b32 v153, v167 offset:1024                         
+	buffer_load_dword v158, v180, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0A56                                  
+	s_branch label_064B                                        
+	
+label_0A56:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xa0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0BAA                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v187, 0, v183                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 64, v183                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 0x80, v183                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 0xc0, v183                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_add_u32_e32 v187, 0x100, v183                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_branch label_0D02                                        
+	
+label_0BAA:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0, v183                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 64, v183                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0x80, v183                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0xc0, v183                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0D02                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v187, 0x100, v183                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v187, s[4:7], 0 offen       
+	v_add_u32_e32 v187, s62, v187                              
+	
+label_0D02:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x640_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1893,7 +1893,7 @@ label_0F04:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2340,14 +2340,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA.s
@@ -1,0 +1,2358 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x2ff                                  
+	s_mov_b32 s63, 0x300                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v179, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v179, v5, v179                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v179, v6, v179                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v179, v4, v179                               
+	v_add_u32_e32 v179, 0x1000, v179                           
+	v_add_u32_e32 v180, 0x1080, v179                           
+	v_add_u32_e32 v181, 0x1080, v180                           
+	v_add_u32_e32 v182, 0x1080, v181                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v183, s63, v183                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	v_add_u32_e32 v184, 0, v184                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 4, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v185, s62, v185                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	v_add_u32_e32 v193, s62, v192                              
+	v_add_u32_e32 v194, s62, v193                              
+	v_add_u32_e32 v195, s62, v194                              
+	v_add_u32_e32 v196, s62, v195                              
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v197, 2, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v197, s63, v197                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	v_add_u32_e32 v202, s62, v201                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v179                                 
+	ds_read_b128 v[16:19], v179 offset:64                      
+	ds_read_b128 v[12:15], v179 offset:512                     
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	ds_read_b128 v[24:27], v180                                
+	ds_read_b128 v[32:35], v180 offset:64                      
+	ds_read_b128 v[28:31], v180 offset:512                     
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x300                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xc0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v203, s36, v5                                 
+	v_add_u32_e32 v203, s62, v203                              
+	v_add_u32_e32 v203, v4, v203                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_071A                                  
+	
+label_0263:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_branch label_0263                                        
+	
+label_071A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0BD1                                  
+	s_branch label_071A                                        
+	
+label_0BD1:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xc0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0D67                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v207, 0, v203                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 64, v203                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0x80, v203                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0xc0, v203                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0x100, v203                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0x140, v203                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_branch label_0F04                                        
+	
+label_0D67:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0, v203                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 64, v203                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0x80, v203                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0xc0, v203                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0x100, v203                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0x140, v203                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	
+label_0F04:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB.s
@@ -1,0 +1,2358 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x2ff                                  
+	s_mov_b32 s63, 0x300                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v179, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v179, v5, v179                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v179, v6, v179                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v179, v4, v179                               
+	v_add_u32_e32 v179, 0x1000, v179                           
+	v_add_u32_e32 v180, 0x1080, v179                           
+	v_add_u32_e32 v181, 0x1080, v180                           
+	v_add_u32_e32 v182, 0x1080, v181                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v183, s63, v183                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	v_add_u32_e32 v184, 0, v184                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 4, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v185, s62, v185                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	v_add_u32_e32 v193, s62, v192                              
+	v_add_u32_e32 v194, s62, v193                              
+	v_add_u32_e32 v195, s62, v194                              
+	v_add_u32_e32 v196, s62, v195                              
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v197, 2, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v197, s63, v197                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	v_add_u32_e32 v202, s62, v201                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v179                                 
+	ds_read_b128 v[16:19], v179 offset:64                      
+	ds_read_b128 v[12:15], v179 offset:512                     
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	ds_read_b128 v[24:27], v180                                
+	ds_read_b128 v[32:35], v180 offset:64                      
+	ds_read_b128 v[28:31], v180 offset:512                     
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x300                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xc0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v203, s36, v5                                 
+	v_add_u32_e32 v203, s62, v203                              
+	v_add_u32_e32 v203, v4, v203                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_071A                                  
+	
+label_0263:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_branch label_0263                                        
+	
+label_071A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v184 offset:2048                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v184 offset:3072                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v179                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v179 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v179 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v179 offset:576                     
+	ds_read_b32 v168, v184                                     
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v200, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v201, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v196, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v196, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v202, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v186, s[16:19], 0 offen offset:1024
+	buffer_load_dword v172, v197, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v188, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v198, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v180                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:576                     
+	ds_read_b32 v169, v184 offset:1024                         
+	buffer_load_dword v174, v199, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0BD1                                  
+	s_branch label_071A                                        
+	
+label_0BD1:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xc0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0D67                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v207, 0, v203                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 64, v203                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0x80, v203                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0xc0, v203                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0x100, v203                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_add_u32_e32 v207, 0x140, v203                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_branch label_0F04                                        
+	
+label_0D67:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0, v203                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 64, v203                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0x80, v203                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0xc0, v203                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0x100, v203                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0F04                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v207, 0x140, v203                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v207, s[4:7], 0 offen       
+	v_add_u32_e32 v207, s62, v207                              
+	
+label_0F04:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x768_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2105,7 +2105,7 @@ label_1106:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2552,14 +2552,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA.s
@@ -1,0 +1,2570 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x37f                                  
+	s_mov_b32 s63, 0x380                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v196, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v196, v5, v196                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v196, v6, v196                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v196, v4, v196                               
+	v_add_u32_e32 v196, 0x1000, v196                           
+	v_add_u32_e32 v197, 0x1080, v196                           
+	v_add_u32_e32 v198, 0x1080, v197                           
+	v_add_u32_e32 v199, 0x1080, v198                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v200, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v200, s63, v200                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v201, 2, v0                              
+	v_add_u32_e32 v201, 0, v201                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v202, 4, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v202, s62, v202                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v216, 2, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v216, s63, v216                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v196                                 
+	ds_read_b128 v[16:19], v196 offset:64                      
+	ds_read_b128 v[12:15], v196 offset:512                     
+	ds_read_b128 v[20:23], v196 offset:576                     
+	ds_read_b32 v184, v201                                     
+	ds_read_b128 v[24:27], v197                                
+	ds_read_b128 v[32:35], v197 offset:64                      
+	ds_read_b128 v[28:31], v197 offset:512                     
+	ds_read_b128 v[36:39], v197 offset:576                     
+	ds_read_b32 v185, v201 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x380                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xe0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v223, s36, v5                                 
+	v_add_u32_e32 v223, s62, v223                              
+	v_add_u32_e32 v223, v4, v223                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_07E9                                  
+	
+label_0286:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v186, v201 offset:2048                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v187, v201 offset:3072                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v196                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v196 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v196 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v196 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v184, v201                                     
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v197                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v185, v201 offset:1024                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_branch label_0286                                        
+	
+label_07E9:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	ds_read_b32 v186, v201 offset:2048                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	ds_read_b32 v187, v201 offset:3072                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v196                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v196 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v196 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v196 offset:576                     
+	ds_read_b32 v184, v201                                     
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v197                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:576                     
+	ds_read_b32 v185, v201 offset:1024                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen            
+	s_cbranch_scc0 label_0D4C                                  
+	s_branch label_07E9                                        
+	
+label_0D4C:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xe0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0F24                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v227, 0, v223                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 64, v223                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x80, v223                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0xc0, v223                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x100, v223                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x140, v223                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x180, v223                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_branch label_1106                                        
+	
+label_0F24:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0, v223                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 64, v223                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x80, v223                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0xc0, v223                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x100, v223                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x140, v223                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x180, v223                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	
+label_1106:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB.s
@@ -1,0 +1,2570 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x37f                                  
+	s_mov_b32 s63, 0x380                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 31                                     
+	s_lshr_b32 s62, s51, 5                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v196, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v196, v5, v196                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v196, v6, v196                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v196, v4, v196                               
+	v_add_u32_e32 v196, 0x1000, v196                           
+	v_add_u32_e32 v197, 0x1080, v196                           
+	v_add_u32_e32 v198, 0x1080, v197                           
+	v_add_u32_e32 v199, 0x1080, v198                           
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 32                                       
+	s_cselect_b32 s62, s63, 32                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v200, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v200, s63, v200                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v201, 2, v0                              
+	v_add_u32_e32 v201, 0, v201                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v202, 4, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v202, s62, v202                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v216, 2, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v216, s63, v216                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v196                                 
+	ds_read_b128 v[16:19], v196 offset:64                      
+	ds_read_b128 v[12:15], v196 offset:512                     
+	ds_read_b128 v[20:23], v196 offset:576                     
+	ds_read_b32 v184, v201                                     
+	ds_read_b128 v[24:27], v197                                
+	ds_read_b128 v[32:35], v197 offset:64                      
+	ds_read_b128 v[28:31], v197 offset:512                     
+	ds_read_b128 v[36:39], v197 offset:576                     
+	ds_read_b32 v185, v201 offset:1024                         
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 32                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x380                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 32                                       
+	s_cselect_b32 s62, s62, 32                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xe0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v223, s36, v5                                 
+	v_add_u32_e32 v223, s62, v223                              
+	v_add_u32_e32 v223, v4, v223                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_07E9                                  
+	
+label_0286:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v186, v201 offset:2048                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v187, v201 offset:3072                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v196                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v196 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v196 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v196 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v184, v201                                     
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[24:27], v197                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	ds_read_b32 v185, v201 offset:1024                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_branch label_0286                                        
+	
+label_07E9:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	ds_read_b32 v186, v201 offset:2048                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[24:27], a[0:3], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[28:31], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[24:27], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[28:31], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[32:35], a[0:3], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[36:39], a[4:7], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[32:35], a[8:11], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[36:39], a[12:15], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[24:27], a[16:19], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[28:31], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[24:27], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[28:31], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[32:35], a[16:19], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[36:39], a[20:23], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[32:35], a[24:27], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[36:39], a[28:31], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[24:27], a[64:67], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[28:31], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[24:27], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[28:31], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[32:35], a[64:67], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[36:39], a[68:71], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[32:35], a[72:75], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[36:39], a[76:79], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[24:27], a[80:83], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[28:31], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[24:27], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[28:31], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[32:35], a[80:83], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[36:39], a[84:87], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[32:35], a[88:91], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[36:39], a[92:95], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[24:27], a[96:99], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[28:31], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[24:27], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[28:31], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[32:35], a[96:99], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[36:39], a[100:103], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[32:35], a[104:107], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[36:39], a[108:111], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	ds_read_b32 v187, v201 offset:3072                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v196                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v196 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v196 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v196 offset:576                     
+	ds_read_b32 v184, v201                                     
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[56:59], a[0:3], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[60:63], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[56:59], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[60:63], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[64:67], a[0:3], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[68:71], a[4:7], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[64:67], a[8:11], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[68:71], a[12:15], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v219, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v220, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v221, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v215, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v215, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v222, s[24:27], 0 offen nt            
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[84:87], v203, s[16:19], 0 offen offset:1024
+	buffer_load_dword v188, v216, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(12)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v205, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v217, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[56:59], a[96:99], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[60:63], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[24:27], v197                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[56:59], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[60:63], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[64:67], a[96:99], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[68:71], a[100:103], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[64:67], a[104:107], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[68:71], a[108:111], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:576                     
+	ds_read_b32 v185, v201 offset:1024                         
+	buffer_load_dword v190, v218, s[24:27], 0 offen nt            
+	s_cbranch_scc0 label_0D4C                                  
+	s_branch label_07E9                                        
+	
+label_0D4C:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xe0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0F24                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v227, 0, v223                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 64, v223                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x80, v223                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0xc0, v223                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x100, v223                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x140, v223                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_add_u32_e32 v227, 0x180, v223                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_branch label_1106                                        
+	
+label_0F24:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0, v223                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 64, v223                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x80, v223                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0xc0, v223                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x100, v223                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x140, v223                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1106                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v227, 0x180, v223                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v227, s[4:7], 0 offen       
+	v_add_u32_e32 v227, s62, v227                              
+	
+label_1106:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_32x896_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024
 .p2align 8
-.type _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024,@function
 
-_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2724,7 +2724,7 @@ label_1604:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -3171,14 +3171,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA.s
@@ -1,0 +1,3189 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x3ff                                  
+	s_lshr_b32 s50, s51, 10                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v214, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v214, v5, v214                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v214, v6, v214                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v214, v4, v214                               
+	v_add_u32_e32 v214, 0x800, v214                            
+	v_add_u32_e32 v215, 0x2100, v214                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v216, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v216, s63, v216                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v217, 2, v0                              
+	v_add_u32_e32 v217, 0, v217                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v218, 4, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v218, s62, v218                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	v_add_u32_e32 v225, s62, v224                              
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	v_add_u32_e32 v228, s62, v227                              
+	v_add_u32_e32 v229, s62, v228                              
+	v_add_u32_e32 v230, s62, v229                              
+	v_add_u32_e32 v231, s62, v230                              
+	v_add_u32_e32 v232, s62, v231                              
+	v_add_u32_e32 v233, s62, v232                              
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v234, 2, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v234, s63, v234                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v235, s62, v234                              
+	v_add_u32_e32 v236, s62, v235                              
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	v_add_u32_e32 v240, s62, v239                              
+	v_add_u32_e32 v241, s62, v240                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v204, v234, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v205, v235, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v206, v236, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	v_accvgpr_write_b32 a240, 0                                
+	v_accvgpr_write_b32 a241, 0                                
+	v_accvgpr_write_b32 a242, 0                                
+	v_accvgpr_write_b32 a243, 0                                
+	v_accvgpr_write_b32 a244, 0                                
+	v_accvgpr_write_b32 a245, 0                                
+	v_accvgpr_write_b32 a246, 0                                
+	v_accvgpr_write_b32 a247, 0                                
+	v_accvgpr_write_b32 a248, 0                                
+	v_accvgpr_write_b32 a249, 0                                
+	v_accvgpr_write_b32 a250, 0                                
+	v_accvgpr_write_b32 a251, 0                                
+	v_accvgpr_write_b32 a252, 0                                
+	v_accvgpr_write_b32 a253, 0                                
+	v_accvgpr_write_b32 a254, 0                                
+	v_accvgpr_write_b32 a255, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v214                                 
+	ds_read_b128 v[16:19], v214 offset:64                      
+	ds_read_b128 v[12:15], v214 offset:512                     
+	ds_read_b128 v[20:23], v214 offset:576                     
+	ds_read_b32 v200, v217                                     
+	ds_read_b128 v[24:27], v214 offset:4224                    
+	ds_read_b128 v[32:35], v214 offset:4288                    
+	ds_read_b128 v[28:31], v214 offset:4736                    
+	ds_read_b128 v[36:39], v214 offset:4800                    
+	ds_read_b32 v201, v217 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x400                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x100                                  
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v242, s36, v5                                 
+	v_add_u32_e32 v242, s62, v242                              
+	v_add_u32_e32 v242, v4, v242                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_089E                                  
+	
+label_0379:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[24:27], a[128:131], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[28:31], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[24:27], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[28:31], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[32:35], a[128:131], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[36:39], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[32:35], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[36:39], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[24:27], a[144:147], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[28:31], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[24:27], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[28:31], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[32:35], a[144:147], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[36:39], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[32:35], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[36:39], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[24:27], a[160:163], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[28:31], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[24:27], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[28:31], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[32:35], a[160:163], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[36:39], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[32:35], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[36:39], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[24:27], a[176:179], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[28:31], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[24:27], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[28:31], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[32:35], a[176:179], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[36:39], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[32:35], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[36:39], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[24:27], a[192:195], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[28:31], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[24:27], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[28:31], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[32:35], a[192:195], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[36:39], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[32:35], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[36:39], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[24:27], a[208:211], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[28:31], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[24:27], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[28:31], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[32:35], a[208:211], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[36:39], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[32:35], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[36:39], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[24:27], a[224:227], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[28:31], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[24:27], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[28:31], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[32:35], a[224:227], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[36:39], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[32:35], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[36:39], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	ds_read_b32 v202, v217 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[24:27], a[240:243], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[28:31], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[24:27], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[28:31], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[32:35], a[240:243], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[36:39], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[32:35], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v215 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[36:39], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v217 offset:1280                         
+	s_cbranch_scc0 label_0DC3                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[56:59], a[128:131], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[60:63], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[56:59], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[60:63], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[64:67], a[128:131], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[68:71], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[64:67], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[68:71], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[56:59], a[192:195], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[60:63], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[56:59], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[60:63], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[64:67], a[192:195], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[68:71], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[64:67], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[68:71], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[56:59], a[208:211], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[60:63], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[56:59], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[60:63], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[64:67], a[208:211], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[68:71], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[64:67], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[68:71], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[56:59], a[224:227], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[60:63], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[56:59], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[60:63], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[64:67], a[224:227], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[68:71], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[64:67], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[68:71], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v214                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v214 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	ds_read_b32 v200, v217                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[56:59], a[240:243], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v214 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[60:63], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[56:59], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[60:63], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[64:67], a[240:243], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[68:71], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v217 offset:256                          
+	s_cbranch_scc0 label_0DC3                                  
+	s_branch label_0379                                        
+	
+label_089E:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[24:27], a[128:131], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[28:31], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[24:27], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[28:31], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[32:35], a[128:131], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[36:39], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[32:35], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[36:39], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[24:27], a[144:147], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[28:31], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[24:27], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[28:31], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[32:35], a[144:147], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[36:39], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[32:35], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[36:39], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[24:27], a[160:163], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[28:31], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[24:27], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[28:31], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[32:35], a[160:163], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[36:39], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[32:35], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[36:39], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[24:27], a[176:179], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[28:31], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[24:27], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[28:31], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[32:35], a[176:179], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[36:39], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[32:35], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[36:39], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[24:27], a[192:195], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[28:31], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[24:27], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[28:31], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[32:35], a[192:195], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[36:39], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[32:35], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[36:39], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[24:27], a[208:211], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[28:31], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[24:27], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[28:31], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[32:35], a[208:211], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[36:39], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[32:35], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[36:39], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[24:27], a[224:227], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[28:31], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[24:27], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[28:31], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[32:35], a[224:227], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[36:39], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[32:35], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[36:39], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	ds_read_b32 v202, v217 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[24:27], a[240:243], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[28:31], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[24:27], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[28:31], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[32:35], a[240:243], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[36:39], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[32:35], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[36:39], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v215 offset:4800                    
+	ds_read_b32 v203, v217 offset:1280                         
+	s_cbranch_scc0 label_0DC3                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[56:59], a[128:131], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[60:63], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[56:59], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[60:63], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[64:67], a[128:131], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[68:71], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[64:67], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[68:71], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[56:59], a[192:195], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[60:63], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[56:59], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[60:63], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[64:67], a[192:195], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[68:71], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[64:67], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[68:71], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[56:59], a[208:211], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[60:63], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[56:59], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[60:63], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[64:67], a[208:211], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[68:71], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[64:67], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[68:71], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[56:59], a[224:227], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[60:63], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[56:59], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[60:63], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[64:67], a[224:227], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[68:71], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[64:67], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[68:71], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v214                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v214 offset:576                     
+	ds_read_b32 v200, v217                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[56:59], a[240:243], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[60:63], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v214 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[56:59], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[60:63], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[64:67], a[240:243], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[68:71], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:4800                    
+	ds_read_b32 v201, v217 offset:256                          
+	s_cbranch_scc0 label_0DC3                                  
+	s_branch label_089E                                        
+	
+label_0DC3:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_i32 s63, s46, 0x100                                  
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x100                                  
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_11DD                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v246, 0, v242                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 64, v242                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x80, v242                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0xc0, v242                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x100, v242                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x140, v242                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x180, v242                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x1c0, v242                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a240                                
+	v_accvgpr_read_b32 v9, a241                                
+	v_accvgpr_read_b32 v10, a242                               
+	v_accvgpr_read_b32 v11, a243                               
+	v_accvgpr_read_b32 v12, a248                               
+	v_accvgpr_read_b32 v13, a249                               
+	v_accvgpr_read_b32 v14, a250                               
+	v_accvgpr_read_b32 v15, a251                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a244                                
+	v_accvgpr_read_b32 v9, a245                                
+	v_accvgpr_read_b32 v10, a246                               
+	v_accvgpr_read_b32 v11, a247                               
+	v_accvgpr_read_b32 v12, a252                               
+	v_accvgpr_read_b32 v13, a253                               
+	v_accvgpr_read_b32 v14, a254                               
+	v_accvgpr_read_b32 v15, a255                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_branch label_1604                                        
+	
+label_11DD:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0, v242                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 64, v242                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x80, v242                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0xc0, v242                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x100, v242                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x140, v242                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x180, v242                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x1c0, v242                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a240                                
+	v_accvgpr_read_b32 v9, a241                                
+	v_accvgpr_read_b32 v10, a242                               
+	v_accvgpr_read_b32 v11, a243                               
+	v_accvgpr_read_b32 v12, a248                               
+	v_accvgpr_read_b32 v13, a249                               
+	v_accvgpr_read_b32 v14, a250                               
+	v_accvgpr_read_b32 v15, a251                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a244                                
+	v_accvgpr_read_b32 v9, a245                                
+	v_accvgpr_read_b32 v10, a246                               
+	v_accvgpr_read_b32 v11, a247                               
+	v_accvgpr_read_b32 v12, a252                               
+	v_accvgpr_read_b32 v13, a253                               
+	v_accvgpr_read_b32 v14, a254                               
+	v_accvgpr_read_b32 v15, a255                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	
+label_1604:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB.s
@@ -1,0 +1,3189 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x3ff                                  
+	s_lshr_b32 s50, s51, 10                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v214, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v214, v5, v214                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v214, v6, v214                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v214, v4, v214                               
+	v_add_u32_e32 v214, 0x800, v214                            
+	v_add_u32_e32 v215, 0x2100, v214                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v216, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v216, s63, v216                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v217, 2, v0                              
+	v_add_u32_e32 v217, 0, v217                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v218, 4, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v218, s62, v218                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	v_add_u32_e32 v225, s62, v224                              
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	v_add_u32_e32 v228, s62, v227                              
+	v_add_u32_e32 v229, s62, v228                              
+	v_add_u32_e32 v230, s62, v229                              
+	v_add_u32_e32 v231, s62, v230                              
+	v_add_u32_e32 v232, s62, v231                              
+	v_add_u32_e32 v233, s62, v232                              
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x400                                    
+	s_cselect_b32 s62, s63, 0x400                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v234, 2, v0                              
+	s_mul_i32 s63, s46, 0x100                                  
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v234, s63, v234                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v235, s62, v234                              
+	v_add_u32_e32 v236, s62, v235                              
+	v_add_u32_e32 v237, s62, v236                              
+	v_add_u32_e32 v238, s62, v237                              
+	v_add_u32_e32 v239, s62, v238                              
+	v_add_u32_e32 v240, s62, v239                              
+	v_add_u32_e32 v241, s62, v240                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v204, v234, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v205, v235, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v206, v236, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	v_accvgpr_write_b32 a240, 0                                
+	v_accvgpr_write_b32 a241, 0                                
+	v_accvgpr_write_b32 a242, 0                                
+	v_accvgpr_write_b32 a243, 0                                
+	v_accvgpr_write_b32 a244, 0                                
+	v_accvgpr_write_b32 a245, 0                                
+	v_accvgpr_write_b32 a246, 0                                
+	v_accvgpr_write_b32 a247, 0                                
+	v_accvgpr_write_b32 a248, 0                                
+	v_accvgpr_write_b32 a249, 0                                
+	v_accvgpr_write_b32 a250, 0                                
+	v_accvgpr_write_b32 a251, 0                                
+	v_accvgpr_write_b32 a252, 0                                
+	v_accvgpr_write_b32 a253, 0                                
+	v_accvgpr_write_b32 a254, 0                                
+	v_accvgpr_write_b32 a255, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v214                                 
+	ds_read_b128 v[16:19], v214 offset:64                      
+	ds_read_b128 v[12:15], v214 offset:512                     
+	ds_read_b128 v[20:23], v214 offset:576                     
+	ds_read_b32 v200, v217                                     
+	ds_read_b128 v[24:27], v214 offset:4224                    
+	ds_read_b128 v[32:35], v214 offset:4288                    
+	ds_read_b128 v[28:31], v214 offset:4736                    
+	ds_read_b128 v[36:39], v214 offset:4800                    
+	ds_read_b32 v201, v217 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x400                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x100                                  
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v242, s36, v5                                 
+	v_add_u32_e32 v242, s62, v242                              
+	v_add_u32_e32 v242, v4, v242                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_089E                                  
+	
+label_0379:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[24:27], a[128:131], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[28:31], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[24:27], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[28:31], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[32:35], a[128:131], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[36:39], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[32:35], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[36:39], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[24:27], a[144:147], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[28:31], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[24:27], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[28:31], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[32:35], a[144:147], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[36:39], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[32:35], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[36:39], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[24:27], a[160:163], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[28:31], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[24:27], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[28:31], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[32:35], a[160:163], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[36:39], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[32:35], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[36:39], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[24:27], a[176:179], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[28:31], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[24:27], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[28:31], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[32:35], a[176:179], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[36:39], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[32:35], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[36:39], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[24:27], a[192:195], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[28:31], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[24:27], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[28:31], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[32:35], a[192:195], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[36:39], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[32:35], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[36:39], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[24:27], a[208:211], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[28:31], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[24:27], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[28:31], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[32:35], a[208:211], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[36:39], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[32:35], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[36:39], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[24:27], a[224:227], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[28:31], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[24:27], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[28:31], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[32:35], a[224:227], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[36:39], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[32:35], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[36:39], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	ds_read_b32 v202, v217 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[24:27], a[240:243], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[28:31], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[24:27], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[28:31], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[32:35], a[240:243], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[36:39], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[32:35], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v215 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[36:39], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v203, v217 offset:1280                         
+	s_cbranch_scc0 label_0DC3                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[56:59], a[128:131], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[60:63], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[56:59], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[60:63], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[64:67], a[128:131], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[68:71], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[64:67], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[68:71], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[56:59], a[192:195], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[60:63], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[56:59], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[60:63], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[64:67], a[192:195], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[68:71], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[64:67], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[68:71], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[56:59], a[208:211], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[60:63], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[56:59], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[60:63], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[64:67], a[208:211], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[68:71], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[64:67], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[68:71], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[56:59], a[224:227], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[60:63], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[56:59], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[60:63], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[64:67], a[224:227], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[68:71], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[64:67], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[68:71], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v214                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v214 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	ds_read_b32 v200, v217                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[56:59], a[240:243], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v214 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[60:63], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[56:59], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[60:63], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[64:67], a[240:243], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[68:71], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v217 offset:256                          
+	s_cbranch_scc0 label_0DC3                                  
+	s_branch label_0379                                        
+	
+label_089E:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v204, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v204, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v204, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v204, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v204, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[24:27], a[128:131], v204, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[28:31], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[24:27], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[28:31], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[32:35], a[128:131], v204, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[36:39], a[132:135], v204, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[32:35], a[136:139], v204, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[36:39], a[140:143], v204, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v205, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v205, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v205, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v205, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v205, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[24:27], a[144:147], v205, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[28:31], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[24:27], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[28:31], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[32:35], a[144:147], v205, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[36:39], a[148:151], v205, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[32:35], a[152:155], v205, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[36:39], a[156:159], v205, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[24:27], a[160:163], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[28:31], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[24:27], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[28:31], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[32:35], a[160:163], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[36:39], a[164:167], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[32:35], a[168:171], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[36:39], a[172:175], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[24:27], a[176:179], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[28:31], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[24:27], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[28:31], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[32:35], a[176:179], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[36:39], a[180:183], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[32:35], a[184:187], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[36:39], a[188:191], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[24:27], a[192:195], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[28:31], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[24:27], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[28:31], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[32:35], a[192:195], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[36:39], a[196:199], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[32:35], a[200:203], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[36:39], a[204:207], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v209, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v209, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v209, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v209, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v209, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[24:27], a[208:211], v209, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[28:31], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[24:27], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[28:31], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[32:35], a[208:211], v209, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[36:39], a[212:215], v209, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[32:35], a[216:219], v209, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[36:39], a[220:223], v209, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v210, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v210, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v210, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v210, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v210, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[24:27], a[224:227], v210, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[28:31], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[24:27], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[28:31], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[32:35], a[224:227], v210, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[36:39], a[228:231], v210, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[32:35], a[232:235], v210, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[36:39], a[236:239], v210, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[8:11], a[112:115], v211, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[12:15], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v215                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[8:11], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[12:15], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[16:19], a[112:115], v211, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[20:23], a[116:119], v211, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[16:19], a[120:123], v211, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[20:23], a[124:127], v211, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:576                     
+	ds_read_b32 v202, v217 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[24:27], a[240:243], v211, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[28:31], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[24:27], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[28:31], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[32:35], a[240:243], v211, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[36:39], a[244:247], v211, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[32:35], a[248:251], v211, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[36:39], a[252:255], v211, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v215 offset:4800                    
+	ds_read_b32 v203, v217 offset:1280                         
+	s_cbranch_scc0 label_0DC3                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v204, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v225, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v204, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v204, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v204, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v225, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v204, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[72:75], v[56:59], a[128:131], v204, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v237, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[72:75], v[60:63], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[76:79], v[56:59], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[76:79], v[60:63], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[80:83], v[64:67], a[128:131], v204, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[80:83], v[68:71], a[132:135], v204, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[84:87], v[64:67], a[136:139], v204, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[84:87], v[68:71], a[140:143], v204, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v205, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v226, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v227, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v205, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v226, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v205, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v205, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v227, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v205, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[88:91], v[56:59], a[144:147], v205, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v238, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[88:91], v[60:63], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[92:95], v[56:59], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[92:95], v[60:63], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[96:99], v[64:67], a[144:147], v205, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[96:99], v[68:71], a[148:151], v205, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[100:103], v[64:67], a[152:155], v205, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[100:103], v[68:71], a[156:159], v205, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v228, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v229, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v228, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v229, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[56:59], a[160:163], v206, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v239, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[60:63], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[56:59], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[60:63], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[64:67], a[160:163], v206, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[68:71], a[164:167], v206, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[64:67], a[168:171], v206, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[68:71], a[172:175], v206, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[168:171], v230, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v231, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v230, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v231, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[56:59], a[176:179], v207, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v240, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[60:63], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[56:59], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[60:63], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[64:67], a[176:179], v207, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[68:71], a[180:183], v207, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[64:67], a[184:187], v207, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[68:71], a[188:191], v207, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[184:187], v232, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v233, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v232, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v233, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[56:59], a[192:195], v208, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v241, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[60:63], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[56:59], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[60:63], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[64:67], a[192:195], v208, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v216, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[68:71], a[196:199], v208, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[64:67], a[200:203], v208, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[68:71], a[204:207], v208, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v209, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v209, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v218, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v209, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v209, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v219, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v209, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[56:59], a[208:211], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v218, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[60:63], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[56:59], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[60:63], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[64:67], a[208:211], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v204, v234, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[68:71], a[212:215], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[64:67], a[216:219], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[68:71], a[220:223], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v210, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v220, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v221, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v210, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v210, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v210, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v210, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[56:59], a[224:227], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v205, v235, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[60:63], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[56:59], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[60:63], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[64:67], a[224:227], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[68:71], a[228:231], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[64:67], a[232:235], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[68:71], a[236:239], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[184:187], v[40:43], a[112:115], v211, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[184:187], v[44:47], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v214                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[188:191], v[40:43], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[188:191], v[44:47], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v214 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[192:195], v[48:51], a[112:115], v211, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[192:195], v[52:55], a[116:119], v211, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v214 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[196:199], v[48:51], a[120:123], v211, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[196:199], v[52:55], a[124:127], v211, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v214 offset:576                     
+	ds_read_b32 v200, v217                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[184:187], v[56:59], a[240:243], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v236, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[184:187], v[60:63], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v214 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[188:191], v[56:59], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[188:191], v[60:63], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v214 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[240:243], v[192:195], v[64:67], a[240:243], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[244:247], v[192:195], v[68:71], a[244:247], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v214 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[248:251], v[196:199], v[64:67], a[248:251], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[252:255], v[196:199], v[68:71], a[252:255], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v214 offset:4800                    
+	ds_read_b32 v201, v217 offset:256                          
+	s_cbranch_scc0 label_0DC3                                  
+	s_branch label_089E                                        
+	
+label_0DC3:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x400                                  
+	s_mul_i32 s63, s46, 0x100                                  
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x100                                  
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_11DD                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v246, 0, v242                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 64, v242                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x80, v242                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0xc0, v242                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x100, v242                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x140, v242                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x180, v242                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_add_u32_e32 v246, 0x1c0, v242                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a240                                
+	v_accvgpr_read_b32 v9, a241                                
+	v_accvgpr_read_b32 v10, a242                               
+	v_accvgpr_read_b32 v11, a243                               
+	v_accvgpr_read_b32 v12, a248                               
+	v_accvgpr_read_b32 v13, a249                               
+	v_accvgpr_read_b32 v14, a250                               
+	v_accvgpr_read_b32 v15, a251                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a244                                
+	v_accvgpr_read_b32 v9, a245                                
+	v_accvgpr_read_b32 v10, a246                               
+	v_accvgpr_read_b32 v11, a247                               
+	v_accvgpr_read_b32 v12, a252                               
+	v_accvgpr_read_b32 v13, a253                               
+	v_accvgpr_read_b32 v14, a254                               
+	v_accvgpr_read_b32 v15, a255                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_branch label_1604                                        
+	
+label_11DD:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0, v242                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 64, v242                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x80, v242                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0xc0, v242                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x100, v242                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x140, v242                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x180, v242                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1604                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v246, 0x1c0, v242                            
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a240                                
+	v_accvgpr_read_b32 v9, a241                                
+	v_accvgpr_read_b32 v10, a242                               
+	v_accvgpr_read_b32 v11, a243                               
+	v_accvgpr_read_b32 v12, a248                               
+	v_accvgpr_read_b32 v13, a249                               
+	v_accvgpr_read_b32 v14, a250                               
+	v_accvgpr_read_b32 v15, a251                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	v_accvgpr_read_b32 v8, a244                                
+	v_accvgpr_read_b32 v9, a245                                
+	v_accvgpr_read_b32 v10, a246                               
+	v_accvgpr_read_b32 v11, a247                               
+	v_accvgpr_read_b32 v12, a252                               
+	v_accvgpr_read_b32 v13, a253                               
+	v_accvgpr_read_b32 v14, a254                               
+	v_accvgpr_read_b32 v15, a255                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v246, s[4:7], 0 offen       
+	v_add_u32_e32 v246, s62, v246                              
+	
+label_1604:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x1024_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1079,7 +1079,7 @@ label_0731:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1526,14 +1526,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA.s
@@ -1,0 +1,1544 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v146, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v146, v5, v146                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v146, v6, v146                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v146, v4, v146                               
+	v_add_u32_e32 v146, 0x1000, v146                           
+	v_add_u32_e32 v147, 0x2100, v146                           
+	v_add_u32_e32 v148, 0x2100, v147                           
+	v_add_u32_e32 v149, 0x2100, v148                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v150, s63, v150                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v151, 2, v0                              
+	v_add_u32_e32 v151, 0, v151                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v152, s62, v152                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v153, s62, v152                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v154, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v154, s63, v154                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v154, s[24:27], 0 offen            
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v154, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v154, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(21)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v146                                 
+	ds_read_b128 v[16:19], v146 offset:64                      
+	ds_read_b128 v[12:15], v146 offset:512                     
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v155, s36, v5                                 
+	v_add_u32_e32 v155, s62, v155                              
+	v_add_u32_e32 v155, v4, v155                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_040A                                  
+	
+label_01F3:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v152, s[16:19], 0 offen    
+	ds_read_b32 v138, v151 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v154, s[24:27], 0 offen            
+	ds_read_b32 v139, v151 offset:1280                         
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[40:43], a[0:3], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[44:47], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[40:43], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[44:47], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[48:51], a[0:3], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[52:55], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[48:51], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[52:55], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	ds_read_b32 v136, v151 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v154, s[24:27], 0 offen            
+	ds_read_b32 v137, v151 offset:2304                         
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	ds_read_b32 v138, v151 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v154, s[24:27], 0 offen            
+	ds_read_b32 v139, v151 offset:3328                         
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[20:23], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	ds_read_b32 v136, v151                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v154, s[24:27], 0 offen            
+	ds_read_b32 v137, v151 offset:256                          
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_branch label_01F3                                        
+	
+label_040A:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v151 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v154, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	ds_read_b32 v139, v151 offset:1280                         
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[40:43], a[0:3], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[44:47], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[40:43], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[44:47], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[48:51], a[0:3], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[52:55], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[48:51], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[52:55], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v151 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v154, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v151 offset:2304                         
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v149 offset:576                     
+	ds_read_b32 v138, v151 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v154, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	ds_read_b32 v139, v151 offset:3328                         
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v154, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_branch label_040A                                        
+	
+label_0621:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_06AC                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v159, 0, v155                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	s_branch label_0731                                        
+	
+label_06AC:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0731                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v159, 0, v155                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	
+label_0731:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB.s
@@ -1,0 +1,1544 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v146, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v146, v5, v146                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v146, v6, v146                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v146, v4, v146                               
+	v_add_u32_e32 v146, 0x1000, v146                           
+	v_add_u32_e32 v147, 0x2100, v146                           
+	v_add_u32_e32 v148, 0x2100, v147                           
+	v_add_u32_e32 v149, 0x2100, v148                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v150, s63, v150                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v151, 2, v0                              
+	v_add_u32_e32 v151, 0, v151                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v152, s62, v152                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v153, s62, v152                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v154, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v154, s63, v154                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v140, v154, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v154, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v154, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(21)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v146                                 
+	ds_read_b128 v[16:19], v146 offset:64                      
+	ds_read_b128 v[12:15], v146 offset:512                     
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v155, s36, v5                                 
+	v_add_u32_e32 v155, s62, v155                              
+	v_add_u32_e32 v155, v4, v155                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_040A                                  
+	
+label_01F3:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v152, s[16:19], 0 offen nt    
+	ds_read_b32 v138, v151 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v154, s[24:27], 0 offen nt            
+	ds_read_b32 v139, v151 offset:1280                         
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[40:43], a[0:3], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[44:47], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[40:43], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[44:47], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[48:51], a[0:3], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[52:55], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[48:51], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[52:55], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	ds_read_b32 v136, v151 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v154, s[24:27], 0 offen nt            
+	ds_read_b32 v137, v151 offset:2304                         
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	ds_read_b32 v138, v151 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v154, s[24:27], 0 offen nt            
+	ds_read_b32 v139, v151 offset:3328                         
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[20:23], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	ds_read_b32 v136, v151                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v154, s[24:27], 0 offen nt            
+	ds_read_b32 v137, v151 offset:256                          
+	s_add_u32 s63, 0x400, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_branch label_01F3                                        
+	
+label_040A:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v151 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[72:75], v[24:27], a[16:19], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[72:75], v[28:31], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[76:79], v[24:27], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[76:79], v[28:31], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[80:83], v[32:35], a[16:19], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[80:83], v[36:39], a[20:23], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[84:87], v[32:35], a[24:27], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v143, v154, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[84:87], v[36:39], a[28:31], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	ds_read_b32 v139, v151 offset:1280                         
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[88:91], v[40:43], a[0:3], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[88:91], v[44:47], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[92:95], v[40:43], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[92:95], v[44:47], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[96:99], v[48:51], a[0:3], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[96:99], v[52:55], a[4:7], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[100:103], v[48:51], a[8:11], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[100:103], v[52:55], a[12:15], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v151 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[56:59], a[16:19], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[60:63], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[56:59], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[60:63], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[64:67], a[16:19], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[68:71], a[20:23], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[64:67], a[24:27], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v154, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[68:71], a[28:31], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v151 offset:2304                         
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v149 offset:576                     
+	ds_read_b32 v138, v151 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v141, v154, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	ds_read_b32 v139, v151 offset:3328                         
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v154, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_0621                                  
+	s_branch label_040A                                        
+	
+label_0621:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_06AC                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v159, 0, v155                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	s_branch label_0731                                        
+	
+label_06AC:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0731                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v159, 0, v155                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v159, s[4:7], 0 offen       
+	v_add_u32_e32 v159, s62, v159                              
+	
+label_0731:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1412,7 +1412,7 @@ label_0AA5:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1859,14 +1859,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA.s
@@ -1,0 +1,1877 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v146, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v146, v5, v146                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v146, v6, v146                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v146, v4, v146                               
+	v_add_u32_e32 v146, 0x1000, v146                           
+	v_add_u32_e32 v147, 0x2100, v146                           
+	v_add_u32_e32 v148, 0x2100, v147                           
+	v_add_u32_e32 v149, 0x2100, v148                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v150, s63, v150                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v151, 2, v0                              
+	v_add_u32_e32 v151, 0, v151                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v152, s62, v152                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	v_add_u32_e32 v155, s62, v154                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v156, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v156, s63, v156                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v157, s62, v156                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v157, s[24:27], 0 offen            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v146                                 
+	ds_read_b128 v[16:19], v146 offset:64                      
+	ds_read_b128 v[12:15], v146 offset:512                     
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v158, s36, v5                                 
+	v_add_u32_e32 v158, s62, v158                              
+	v_add_u32_e32 v158, v4, v158                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_054D                                  
+	
+label_020A:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	ds_read_b32 v138, v151 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v139, v151 offset:1280                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	ds_read_b32 v136, v151 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v137, v151 offset:2304                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	ds_read_b32 v138, v151 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v139, v151 offset:3328                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	ds_read_b32 v136, v151                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v137, v151 offset:256                          
+	s_cbranch_scc0 label_0890                                  
+	s_branch label_020A                                        
+	
+label_054D:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v151 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	ds_read_b32 v139, v151 offset:1280                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v151 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v151 offset:2304                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v149 offset:576                     
+	ds_read_b32 v138, v151 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	ds_read_b32 v139, v151 offset:3328                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_cbranch_scc0 label_0890                                  
+	s_branch label_054D                                        
+	
+label_0890:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_099C                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v162, 0, v158                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_add_u32_e32 v162, 64, v158                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	s_branch label_0AA5                                        
+	
+label_099C:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AA5                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v162, 0, v158                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AA5                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v162, 64, v158                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	
+label_0AA5:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB.s
@@ -1,0 +1,1877 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v146, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v146, v5, v146                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v146, v6, v146                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v146, v4, v146                               
+	v_add_u32_e32 v146, 0x1000, v146                           
+	v_add_u32_e32 v147, 0x2100, v146                           
+	v_add_u32_e32 v148, 0x2100, v147                           
+	v_add_u32_e32 v149, 0x2100, v148                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v150, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v150, s63, v150                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v151, 2, v0                              
+	v_add_u32_e32 v151, 0, v151                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v152, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v152, s62, v152                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	v_add_u32_e32 v155, s62, v154                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v156, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v156, s63, v156                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v157, s62, v156                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	buffer_load_dword v141, v157, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(18)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v146                                 
+	ds_read_b128 v[16:19], v146 offset:64                      
+	ds_read_b128 v[12:15], v146 offset:512                     
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v158, s36, v5                                 
+	v_add_u32_e32 v158, s62, v158                              
+	v_add_u32_e32 v158, v4, v158                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_054D                                  
+	
+label_020A:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	ds_read_b32 v138, v151 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v139, v151 offset:1280                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v148 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	ds_read_b32 v136, v151 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v137, v151 offset:2304                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[52:55], v149 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	ds_read_b32 v138, v151 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v139, v151 offset:3328                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[20:23], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	ds_read_b32 v136, v151                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v137, v151 offset:256                          
+	s_cbranch_scc0 label_0890                                  
+	s_branch label_020A                                        
+	
+label_054D:
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v151 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	ds_read_b32 v139, v151 offset:1280                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v148                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[16:19], v148 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v148 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v148 offset:576                     
+	ds_read_b32 v136, v151 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[24:27], v148 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[32:35], v148 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v148 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v148 offset:4800                    
+	ds_read_b32 v137, v151 offset:2304                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[72:75], v[24:27], a[32:35], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[72:75], v[28:31], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[76:79], v[24:27], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[76:79], v[28:31], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[80:83], v[32:35], a[32:35], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[80:83], v[36:39], a[36:39], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[84:87], v[32:35], a[40:43], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[84:87], v[36:39], a[44:47], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v149                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[48:51], v149 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[72:75], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[44:47], v149 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[76:79], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[52:55], v149 offset:576                     
+	ds_read_b32 v138, v151 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[88:91], v[24:27], a[48:51], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[80:83], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[88:91], v[28:31], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v149 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[92:95], v[24:27], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[84:87], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[92:95], v[28:31], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v149 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[96:99], v[32:35], a[48:51], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v140, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[96:99], v[36:39], a[52:55], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v149 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[100:103], v[32:35], a[56:59], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[100:103], v[36:39], a[60:63], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v149 offset:4800                    
+	ds_read_b32 v139, v151 offset:3328                         
+	s_cbranch_scc0 label_0890                                  
+	s_waitcnt vmcnt(13) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[40:43], a[0:3], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[88:91], v154, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[44:47], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[40:43], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[92:95], v155, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[44:47], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[48:51], a[0:3], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[52:55], a[4:7], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[48:51], a[8:11], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[52:55], a[12:15], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[56:59], a[32:35], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v157, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[60:63], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[56:59], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[60:63], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[64:67], a[32:35], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v150, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[68:71], a[36:39], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[64:67], a[40:43], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[68:71], a[44:47], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[40:43], a[16:19], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[44:47], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[40:43], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[44:47], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[48:51], a[16:19], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v152, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[52:55], a[20:23], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[48:51], a[24:27], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v153, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[52:55], a[28:31], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v151                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v142, v156, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v151 offset:256                          
+	s_cbranch_scc0 label_0890                                  
+	s_branch label_054D                                        
+	
+label_0890:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_099C                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v162, 0, v158                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_add_u32_e32 v162, 64, v158                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	s_branch label_0AA5                                        
+	
+label_099C:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AA5                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v162, 0, v158                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0AA5                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v162, 64, v158                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v162, s[4:7], 0 offen       
+	v_add_u32_e32 v162, s62, v162                              
+	
+label_0AA5:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1359,7 +1359,7 @@ label_09E0:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1806,14 +1806,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA.s
@@ -1,0 +1,1824 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v180, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v180, v5, v180                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v180, v6, v180                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v180, v4, v180                               
+	v_add_u32_e32 v180, 0x800, v180                            
+	v_add_u32_e32 v181, 0x2100, v180                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v182, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v182, s63, v182                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	v_add_u32_e32 v183, 0, v183                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v184, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v184, s62, v184                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v185, s62, v184                              
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v190, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v190, s63, v190                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v172, v190, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v173, v191, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dword v174, v192, s[24:27], 0 offen            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v180                                 
+	ds_read_b128 v[16:19], v180 offset:64                      
+	ds_read_b128 v[12:15], v180 offset:512                     
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v193, s36, v5                                 
+	v_add_u32_e32 v193, s62, v193                              
+	v_add_u32_e32 v193, v4, v193                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_048B                                  
+	
+label_0254:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v184, s[16:19], 0 offen    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v190, s[24:27], 0 offen            
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_06C2                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v190, s[24:27], 0 offen            
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[40:43], a[16:19], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[44:47], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[40:43], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[44:47], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[48:51], a[16:19], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[52:55], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[48:51], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[52:55], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_06C2                                  
+	s_branch label_0254                                        
+	
+label_048B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v184, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v190, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_06C2                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v190, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[40:43], a[16:19], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[44:47], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[40:43], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[44:47], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[48:51], a[16:19], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[52:55], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[48:51], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[52:55], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_06C2                                  
+	s_branch label_048B                                        
+	
+label_06C2:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0852                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, 0x80, v193                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_branch label_09E0                                        
+	
+label_0852:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_09E0                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_09E0                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_09E0                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 0x80, v193                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	
+label_09E0:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB.s
@@ -1,0 +1,1824 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v180, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v180, v5, v180                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v180, v6, v180                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v180, v4, v180                               
+	v_add_u32_e32 v180, 0x800, v180                            
+	v_add_u32_e32 v181, 0x2100, v180                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v182, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v182, s63, v182                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	v_add_u32_e32 v183, 0, v183                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v184, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v184, s62, v184                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v185, s62, v184                              
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v190, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v190, s63, v190                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v172, v190, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v173, v191, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	buffer_load_dword v174, v192, s[24:27], 0 offen nt            
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v180                                 
+	ds_read_b128 v[16:19], v180 offset:64                      
+	ds_read_b128 v[12:15], v180 offset:512                     
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v193, s36, v5                                 
+	v_add_u32_e32 v193, s62, v193                              
+	v_add_u32_e32 v193, v4, v193                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_048B                                  
+	
+label_0254:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v184, s[16:19], 0 offen nt    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v190, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_06C2                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v190, s[24:27], 0 offen nt            
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[40:43], a[16:19], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[44:47], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[40:43], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[44:47], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[48:51], a[16:19], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[52:55], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[48:51], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[52:55], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_06C2                                  
+	s_branch label_0254                                        
+	
+label_048B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v184, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[72:75], v[24:27], a[48:51], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[72:75], v[28:31], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[76:79], v[24:27], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[76:79], v[28:31], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[80:83], v[32:35], a[48:51], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[80:83], v[36:39], a[52:55], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[84:87], v[32:35], a[56:59], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v190, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[84:87], v[36:39], a[60:63], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[88:91], v[24:27], a[64:67], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[88:91], v[28:31], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[92:95], v[24:27], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[92:95], v[28:31], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[96:99], v[32:35], a[64:67], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[96:99], v[36:39], a[68:71], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[100:103], v[32:35], a[72:75], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[100:103], v[36:39], a[76:79], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_06C2                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[40:43], a[0:3], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[44:47], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[40:43], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[44:47], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[48:51], a[0:3], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[52:55], a[4:7], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[48:51], a[8:11], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[52:55], a[12:15], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[56:59], a[48:51], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[60:63], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[56:59], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[60:63], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[64:67], a[48:51], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[68:71], a[52:55], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[64:67], a[56:59], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v190, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[68:71], a[60:63], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[40:43], a[16:19], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[44:47], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[40:43], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[44:47], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[48:51], a[16:19], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[52:55], a[20:23], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[48:51], a[24:27], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[52:55], a[28:31], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[56:59], a[64:67], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[60:63], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[56:59], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[60:63], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[64:67], a[64:67], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[68:71], a[68:71], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[64:67], a[72:75], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[68:71], a[76:79], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[40:43], a[32:35], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[44:47], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[40:43], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[44:47], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[48:51], a[32:35], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[52:55], a[36:39], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[48:51], a[40:43], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[52:55], a[44:47], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[56:59], a[80:83], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[60:63], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[56:59], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[60:63], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[64:67], a[80:83], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[68:71], a[84:87], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[64:67], a[88:91], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[68:71], a[92:95], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_06C2                                  
+	s_branch label_048B                                        
+	
+label_06C2:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0852                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, 0x80, v193                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_branch label_09E0                                        
+	
+label_0852:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_09E0                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_09E0                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_09E0                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 0x80, v193                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	
+label_09E0:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x384_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1604,7 +1604,7 @@ label_0C2C:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2051,14 +2051,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA.s
@@ -1,0 +1,2069 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x1ff                                  
+	s_lshr_b32 s50, s51, 9                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v146, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v146, v5, v146                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v146, v6, v146                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v146, v4, v146                               
+	v_add_u32_e32 v146, 0x800, v146                            
+	v_add_u32_e32 v147, 0x2100, v146                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v148, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v148, s63, v148                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	v_add_u32_e32 v149, 0, v149                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v150, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v150, s62, v150                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v151, s62, v150                              
+	v_add_u32_e32 v152, s62, v151                              
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	v_add_u32_e32 v155, s62, v154                              
+	v_add_u32_e32 v156, s62, v155                              
+	v_add_u32_e32 v157, s62, v156                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v158, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v158, s63, v158                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v159, s62, v158                              
+	v_add_u32_e32 v160, s62, v159                              
+	v_add_u32_e32 v161, s62, v160                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v142, v160, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v146                                 
+	ds_read_b128 v[16:19], v146 offset:64                      
+	ds_read_b128 v[12:15], v146 offset:512                     
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v149                                     
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v149 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x80                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v162, s36, v5                                 
+	v_add_u32_e32 v162, s62, v162                              
+	v_add_u32_e32 v162, v4, v162                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_053A                                  
+	
+label_026D:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[24:27], a[64:67], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[28:31], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[24:27], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[28:31], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[32:35], a[64:67], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[36:39], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[32:35], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[36:39], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[24:27], a[80:83], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[28:31], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[24:27], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[28:31], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[32:35], a[80:83], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[36:39], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[32:35], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[36:39], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[24:27], a[96:99], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[28:31], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[24:27], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[28:31], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[32:35], a[96:99], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[36:39], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[32:35], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[36:39], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	ds_read_b32 v138, v149 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[24:27], a[112:115], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[28:31], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[24:27], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[28:31], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[32:35], a[112:115], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[36:39], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v149 offset:1280                         
+	s_cbranch_scc0 label_0807                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[56:59], a[64:67], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[60:63], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[56:59], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[60:63], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[64:67], a[64:67], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[68:71], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[64:67], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[68:71], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[56:59], a[80:83], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[60:63], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[56:59], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[60:63], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[64:67], a[80:83], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[68:71], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[64:67], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[68:71], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	ds_read_b32 v136, v149                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v149 offset:256                          
+	s_cbranch_scc0 label_0807                                  
+	s_branch label_026D                                        
+	
+label_053A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[24:27], a[64:67], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[28:31], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[24:27], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[28:31], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[32:35], a[64:67], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[36:39], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[32:35], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[36:39], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[24:27], a[80:83], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[28:31], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[24:27], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[28:31], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[32:35], a[80:83], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[36:39], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[32:35], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[36:39], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[24:27], a[96:99], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[28:31], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[24:27], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[28:31], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[32:35], a[96:99], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[36:39], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[32:35], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[36:39], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v149 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[24:27], a[112:115], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[28:31], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[24:27], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[28:31], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[32:35], a[112:115], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[36:39], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	ds_read_b32 v139, v149 offset:1280                         
+	s_cbranch_scc0 label_0807                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[56:59], a[64:67], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[60:63], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[56:59], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[60:63], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[64:67], a[64:67], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[68:71], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[64:67], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[68:71], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[56:59], a[80:83], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[60:63], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[56:59], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[60:63], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[64:67], a[80:83], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[68:71], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[64:67], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[68:71], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v149                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v149 offset:256                          
+	s_cbranch_scc0 label_0807                                  
+	s_branch label_053A                                        
+	
+label_0807:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_i32 s63, s46, 0x80                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x80                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0A19                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v166, 0, v162                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_add_u32_e32 v166, 64, v162                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_add_u32_e32 v166, 0x80, v162                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_add_u32_e32 v166, 0xc0, v162                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_branch label_0C2C                                        
+	
+label_0A19:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 0, v162                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 64, v162                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 0x80, v162                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 0xc0, v162                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	
+label_0C2C:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB.s
@@ -1,0 +1,2069 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x1ff                                  
+	s_lshr_b32 s50, s51, 9                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0039:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_003E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0039                                        
+	
+label_003E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0044                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0064                                        
+	
+label_0044:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0064:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v144, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v144, v4, v144                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v144, s62, v144                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v145, s62, v144                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v146, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v146, v5, v146                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v146, v6, v146                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v146, v4, v146                               
+	v_add_u32_e32 v146, 0x800, v146                            
+	v_add_u32_e32 v147, 0x2100, v146                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v148, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v148, s63, v148                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v149, 2, v0                              
+	v_add_u32_e32 v149, 0, v149                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v150, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v150, s62, v150                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v151, s62, v150                              
+	v_add_u32_e32 v152, s62, v151                              
+	v_add_u32_e32 v153, s62, v152                              
+	v_add_u32_e32 v154, s62, v153                              
+	v_add_u32_e32 v155, s62, v154                              
+	v_add_u32_e32 v156, s62, v155                              
+	v_add_u32_e32 v157, s62, v156                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v158, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v158, s63, v158                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v159, s62, v158                              
+	v_add_u32_e32 v160, s62, v159                              
+	v_add_u32_e32 v161, s62, v160                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v142, v160, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v146                                 
+	ds_read_b128 v[16:19], v146 offset:64                      
+	ds_read_b128 v[12:15], v146 offset:512                     
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v149                                     
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v149 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x80                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v162, s36, v5                                 
+	v_add_u32_e32 v162, s62, v162                              
+	v_add_u32_e32 v162, v4, v162                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_053A                                  
+	
+label_026D:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[24:27], a[64:67], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[28:31], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[24:27], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[28:31], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[32:35], a[64:67], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[36:39], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[32:35], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[36:39], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[24:27], a[80:83], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[28:31], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[24:27], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[28:31], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[32:35], a[80:83], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[36:39], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[32:35], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[36:39], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[24:27], a[96:99], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[28:31], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[24:27], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[28:31], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[32:35], a[96:99], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[36:39], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[32:35], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[36:39], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	ds_read_b32 v138, v149 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[24:27], a[112:115], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[28:31], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[24:27], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[28:31], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[32:35], a[112:115], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[36:39], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v139, v149 offset:1280                         
+	s_cbranch_scc0 label_0807                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[56:59], a[64:67], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[60:63], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[56:59], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[60:63], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[64:67], a[64:67], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[68:71], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[64:67], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[68:71], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[56:59], a[80:83], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[60:63], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[56:59], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[60:63], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[64:67], a[80:83], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[68:71], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[64:67], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[68:71], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v146 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	ds_read_b32 v136, v149                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v137, v149 offset:256                          
+	s_cbranch_scc0 label_0807                                  
+	s_branch label_026D                                        
+	
+label_053A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v140, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v140, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v140, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v140, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v140, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[24:27], a[64:67], v140, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[28:31], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[24:27], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[28:31], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[32:35], a[64:67], v140, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[36:39], a[68:71], v140, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[32:35], a[72:75], v140, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[36:39], a[76:79], v140, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v141, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v141, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v141, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v141, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v141, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[24:27], a[80:83], v141, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[28:31], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[24:27], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[28:31], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[32:35], a[80:83], v141, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[36:39], a[84:87], v141, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[32:35], a[88:91], v141, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[36:39], a[92:95], v141, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v142, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v142, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v142, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v142, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v142, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[24:27], a[96:99], v142, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[28:31], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[24:27], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[28:31], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[32:35], a[96:99], v142, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[36:39], a[100:103], v142, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[32:35], a[104:107], v142, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[36:39], a[108:111], v142, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v143, v136 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v147                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v147 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v143, v136 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v143, v136 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v147 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v143, v136 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v143, v136 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v147 offset:576                     
+	ds_read_b32 v138, v149 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[24:27], a[112:115], v143, v137 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[28:31], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v147 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[24:27], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[28:31], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v147 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[32:35], a[112:115], v143, v137 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[36:39], a[116:119], v143, v137 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v147 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[32:35], a[120:123], v143, v137 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[36:39], a[124:127], v143, v137 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v147 offset:4800                    
+	ds_read_b32 v139, v149 offset:1280                         
+	s_cbranch_scc0 label_0807                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v140, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[120:123], v156, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v157, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v140, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v156, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v140, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v140, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v157, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v140, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[72:75], v[56:59], a[64:67], v140, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v143, v161, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[72:75], v[60:63], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[76:79], v[56:59], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[76:79], v[60:63], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[80:83], v[64:67], a[64:67], v140, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v148, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[80:83], v[68:71], a[68:71], v140, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[84:87], v[64:67], a[72:75], v140, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[84:87], v[68:71], a[76:79], v140, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v141, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v144, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v145, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v141, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v150, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v141, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v141, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v151, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v141, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[88:91], v[56:59], a[80:83], v141, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v150, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[88:91], v[60:63], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[92:95], v[56:59], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v151, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[92:95], v[60:63], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[96:99], v[64:67], a[80:83], v141, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v140, v158, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[96:99], v[68:71], a[84:87], v141, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[100:103], v[64:67], a[88:91], v141, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[100:103], v[68:71], a[92:95], v141, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v142, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v152, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v153, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v142, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v152, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v142, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v142, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v153, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v142, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[56:59], a[96:99], v142, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v141, v159, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[60:63], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[56:59], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[60:63], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[64:67], a[96:99], v142, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[68:71], a[100:103], v142, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[64:67], a[104:107], v142, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[68:71], a[108:111], v142, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v143, v138 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v154, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v146                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v155, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v146 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v143, v138 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v154, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v143, v138 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v146 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v143, v138 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v155, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v143, v138 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v146 offset:576                     
+	ds_read_b32 v136, v149                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[56:59], a[112:115], v143, v139 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v142, v160, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[60:63], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v146 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[56:59], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[60:63], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v146 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[64:67], a[112:115], v143, v139 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[68:71], a[116:119], v143, v139 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v146 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[64:67], a[120:123], v143, v139 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[68:71], a[124:127], v143, v139 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v146 offset:4800                    
+	ds_read_b32 v137, v149 offset:256                          
+	s_cbranch_scc0 label_0807                                  
+	s_branch label_053A                                        
+	
+label_0807:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_i32 s63, s46, 0x80                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x80                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0A19                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v166, 0, v162                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_add_u32_e32 v166, 64, v162                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_add_u32_e32 v166, 0x80, v162                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_add_u32_e32 v166, 0xc0, v162                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_branch label_0C2C                                        
+	
+label_0A19:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 0, v162                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 64, v162                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 0x80, v162                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0C2C                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v166, 0xc0, v162                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v166, s[4:7], 0 offen       
+	v_add_u32_e32 v166, s62, v166                              
+	
+label_0C2C:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x512_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1909,7 +1909,7 @@ label_0EC1:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2356,14 +2356,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA.s
@@ -1,0 +1,2374 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x27f                                  
+	s_mov_b32 s63, 0x280                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v162, s62, v161                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v163, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v163, v5, v163                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v163, v6, v163                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v163, v4, v163                               
+	v_add_u32_e32 v163, 0x800, v163                            
+	v_add_u32_e32 v164, 0x2100, v163                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v165, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v165, s63, v165                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v166, 2, v0                              
+	v_add_u32_e32 v166, 0, v166                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v167, 4, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v167, s62, v167                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v168, s62, v167                              
+	v_add_u32_e32 v169, s62, v168                              
+	v_add_u32_e32 v170, s62, v169                              
+	v_add_u32_e32 v171, s62, v170                              
+	v_add_u32_e32 v172, s62, v171                              
+	v_add_u32_e32 v173, s62, v172                              
+	v_add_u32_e32 v174, s62, v173                              
+	v_add_u32_e32 v175, s62, v174                              
+	v_add_u32_e32 v176, s62, v175                              
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v177, 2, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v177, s63, v177                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v178, s62, v177                              
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v156, v177, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v157, v178, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v158, v179, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v163                                 
+	ds_read_b128 v[16:19], v163 offset:64                      
+	ds_read_b128 v[12:15], v163 offset:512                     
+	ds_read_b128 v[20:23], v163 offset:576                     
+	ds_read_b32 v152, v166                                     
+	ds_read_b128 v[24:27], v163 offset:4224                    
+	ds_read_b128 v[32:35], v163 offset:4288                    
+	ds_read_b128 v[28:31], v163 offset:4736                    
+	ds_read_b128 v[36:39], v163 offset:4800                    
+	ds_read_b32 v153, v166 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x280                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xa0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v182, s36, v5                                 
+	v_add_u32_e32 v182, s62, v182                              
+	v_add_u32_e32 v182, v4, v182                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0632                                  
+	
+label_02CF:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[24:27], a[80:83], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[28:31], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[24:27], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[28:31], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[32:35], a[80:83], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[36:39], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[32:35], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[36:39], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[24:27], a[96:99], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[28:31], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[24:27], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[28:31], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[32:35], a[96:99], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[36:39], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[32:35], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[36:39], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[24:27], a[112:115], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[28:31], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[24:27], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[28:31], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[32:35], a[112:115], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[36:39], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[32:35], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[36:39], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[24:27], a[128:131], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[28:31], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[24:27], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[28:31], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[32:35], a[128:131], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[36:39], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[32:35], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[36:39], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	ds_read_b32 v154, v166 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[24:27], a[144:147], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v164 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[28:31], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[24:27], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v164 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[28:31], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[32:35], a[144:147], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v164 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[36:39], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[32:35], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v164 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[36:39], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v155, v166 offset:1280                         
+	s_cbranch_scc0 label_0995                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[56:59], a[80:83], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[60:63], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[56:59], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[60:63], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[64:67], a[80:83], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[68:71], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[64:67], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[68:71], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[56:59], a[128:131], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[60:63], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[56:59], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[60:63], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[64:67], a[128:131], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[68:71], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[64:67], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[68:71], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v163                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v163 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	ds_read_b32 v152, v166                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v163 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v153, v166 offset:256                          
+	s_cbranch_scc0 label_0995                                  
+	s_branch label_02CF                                        
+	
+label_0632:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[24:27], a[80:83], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[28:31], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[24:27], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[28:31], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[32:35], a[80:83], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[36:39], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[32:35], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[36:39], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[24:27], a[96:99], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[28:31], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[24:27], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[28:31], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[32:35], a[96:99], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[36:39], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[32:35], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[36:39], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[24:27], a[112:115], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[28:31], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[24:27], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[28:31], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[32:35], a[112:115], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[36:39], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[32:35], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[36:39], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[24:27], a[128:131], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[28:31], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[24:27], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[28:31], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[32:35], a[128:131], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[36:39], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[32:35], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[36:39], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	ds_read_b32 v154, v166 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[24:27], a[144:147], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[28:31], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v164 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[24:27], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[28:31], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v164 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[32:35], a[144:147], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[36:39], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v164 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[32:35], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[36:39], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v164 offset:4800                    
+	ds_read_b32 v155, v166 offset:1280                         
+	s_cbranch_scc0 label_0995                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[56:59], a[80:83], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[60:63], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[56:59], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[60:63], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[64:67], a[80:83], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[68:71], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[64:67], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[68:71], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[56:59], a[128:131], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[60:63], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[56:59], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[60:63], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[64:67], a[128:131], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[68:71], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[64:67], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[68:71], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v163                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v163 offset:576                     
+	ds_read_b32 v152, v166                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v163 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:4800                    
+	ds_read_b32 v153, v166 offset:256                          
+	s_cbranch_scc0 label_0995                                  
+	s_branch label_0632                                        
+	
+label_0995:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xa0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0C29                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v186, 0, v182                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 64, v182                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 0x80, v182                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 0xc0, v182                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 0x100, v182                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_branch label_0EC1                                        
+	
+label_0C29:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0, v182                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 64, v182                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0x80, v182                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0xc0, v182                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0x100, v182                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	
+label_0EC1:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB.s
@@ -1,0 +1,2374 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x27f                                  
+	s_mov_b32 s63, 0x280                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v161, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v161, v4, v161                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v161, s62, v161                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v162, s62, v161                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v163, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v163, v5, v163                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v163, v6, v163                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v163, v4, v163                               
+	v_add_u32_e32 v163, 0x800, v163                            
+	v_add_u32_e32 v164, 0x2100, v163                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v165, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v165, s63, v165                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v166, 2, v0                              
+	v_add_u32_e32 v166, 0, v166                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v167, 4, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v167, s62, v167                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v168, s62, v167                              
+	v_add_u32_e32 v169, s62, v168                              
+	v_add_u32_e32 v170, s62, v169                              
+	v_add_u32_e32 v171, s62, v170                              
+	v_add_u32_e32 v172, s62, v171                              
+	v_add_u32_e32 v173, s62, v172                              
+	v_add_u32_e32 v174, s62, v173                              
+	v_add_u32_e32 v175, s62, v174                              
+	v_add_u32_e32 v176, s62, v175                              
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v177, 2, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v177, s63, v177                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v178, s62, v177                              
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	v_add_u32_e32 v181, s62, v180                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v156, v177, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v157, v178, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v158, v179, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v163                                 
+	ds_read_b128 v[16:19], v163 offset:64                      
+	ds_read_b128 v[12:15], v163 offset:512                     
+	ds_read_b128 v[20:23], v163 offset:576                     
+	ds_read_b32 v152, v166                                     
+	ds_read_b128 v[24:27], v163 offset:4224                    
+	ds_read_b128 v[32:35], v163 offset:4288                    
+	ds_read_b128 v[28:31], v163 offset:4736                    
+	ds_read_b128 v[36:39], v163 offset:4800                    
+	ds_read_b32 v153, v166 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x280                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xa0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v182, s36, v5                                 
+	v_add_u32_e32 v182, s62, v182                              
+	v_add_u32_e32 v182, v4, v182                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0632                                  
+	
+label_02CF:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[24:27], a[80:83], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[28:31], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[24:27], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[28:31], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[32:35], a[80:83], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[36:39], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[32:35], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[36:39], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[24:27], a[96:99], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[28:31], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[24:27], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[28:31], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[32:35], a[96:99], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[36:39], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[32:35], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[36:39], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[24:27], a[112:115], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[28:31], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[24:27], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[28:31], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[32:35], a[112:115], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[36:39], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[32:35], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[36:39], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[24:27], a[128:131], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[28:31], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[24:27], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[28:31], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[32:35], a[128:131], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[36:39], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[32:35], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[36:39], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	ds_read_b32 v154, v166 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[24:27], a[144:147], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v164 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[28:31], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[24:27], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v164 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[28:31], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[32:35], a[144:147], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v164 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[36:39], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[32:35], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v164 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[36:39], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v155, v166 offset:1280                         
+	s_cbranch_scc0 label_0995                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[56:59], a[80:83], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[60:63], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[56:59], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[60:63], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[64:67], a[80:83], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[68:71], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[64:67], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[68:71], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[56:59], a[128:131], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[60:63], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[56:59], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[60:63], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[64:67], a[128:131], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[68:71], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[64:67], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[68:71], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v163                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v163 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	ds_read_b32 v152, v166                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v163 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v153, v166 offset:256                          
+	s_cbranch_scc0 label_0995                                  
+	s_branch label_02CF                                        
+	
+label_0632:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v156, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v156, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v156, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v156, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v156, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[24:27], a[80:83], v156, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[28:31], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[24:27], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[28:31], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[32:35], a[80:83], v156, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[36:39], a[84:87], v156, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[32:35], a[88:91], v156, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[36:39], a[92:95], v156, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v157, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v157, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v157, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v157, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v157, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[24:27], a[96:99], v157, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[28:31], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[24:27], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[28:31], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[32:35], a[96:99], v157, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[36:39], a[100:103], v157, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[32:35], a[104:107], v157, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[36:39], a[108:111], v157, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v158, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v158, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v158, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v158, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v158, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[24:27], a[112:115], v158, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[28:31], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[24:27], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[28:31], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[32:35], a[112:115], v158, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[36:39], a[116:119], v158, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[32:35], a[120:123], v158, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[36:39], a[124:127], v158, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v159, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v159, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v159, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v159, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v159, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[24:27], a[128:131], v159, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[28:31], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[24:27], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[28:31], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[32:35], a[128:131], v159, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[36:39], a[132:135], v159, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[32:35], a[136:139], v159, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[36:39], a[140:143], v159, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v160, v152 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v164                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v164 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v160, v152 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v160, v152 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v164 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v160, v152 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v160, v152 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v164 offset:576                     
+	ds_read_b32 v154, v166 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[24:27], a[144:147], v160, v153 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[28:31], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v164 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[24:27], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[28:31], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v164 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[32:35], a[144:147], v160, v153 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[36:39], a[148:151], v160, v153 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v164 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[32:35], a[152:155], v160, v153 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[36:39], a[156:159], v160, v153 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v164 offset:4800                    
+	ds_read_b32 v155, v166 offset:1280                         
+	s_cbranch_scc0 label_0995                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v156, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v173, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v174, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v156, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v173, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v156, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v156, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v174, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v156, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[72:75], v[56:59], a[80:83], v156, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v159, v180, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[72:75], v[60:63], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[76:79], v[56:59], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[76:79], v[60:63], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[80:83], v[64:67], a[80:83], v156, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[80:83], v[68:71], a[84:87], v156, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[84:87], v[64:67], a[88:91], v156, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[84:87], v[68:71], a[92:95], v156, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v157, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[136:139], v175, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v176, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v157, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v175, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v157, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v157, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v176, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v157, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[88:91], v[56:59], a[96:99], v157, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v160, v181, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[88:91], v[60:63], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[92:95], v[56:59], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[92:95], v[60:63], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[96:99], v[64:67], a[96:99], v157, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v165, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[96:99], v[68:71], a[100:103], v157, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[100:103], v[64:67], a[104:107], v157, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[100:103], v[68:71], a[108:111], v157, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v158, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v161, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v162, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v158, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v167, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v158, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v158, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v168, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v158, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[104:107], v[56:59], a[112:115], v158, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v167, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[104:107], v[60:63], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[108:111], v[56:59], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v168, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[108:111], v[60:63], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[112:115], v[64:67], a[112:115], v158, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v156, v177, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[112:115], v[68:71], a[116:119], v158, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[116:119], v[64:67], a[120:123], v158, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[116:119], v[68:71], a[124:127], v158, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v159, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v169, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v170, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v159, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v169, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v159, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v159, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v170, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v159, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[120:123], v[56:59], a[128:131], v159, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v157, v178, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[120:123], v[60:63], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[124:127], v[56:59], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[124:127], v[60:63], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[128:131], v[64:67], a[128:131], v159, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[128:131], v[68:71], a[132:135], v159, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[132:135], v[64:67], a[136:139], v159, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[132:135], v[68:71], a[140:143], v159, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v160, v154 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v171, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v163                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v172, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v163 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v160, v154 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v171, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v160, v154 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v163 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v160, v154 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v172, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v160, v154 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v163 offset:576                     
+	ds_read_b32 v152, v166                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[136:139], v[56:59], a[144:147], v160, v155 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v158, v179, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[136:139], v[60:63], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v163 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[140:143], v[56:59], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[140:143], v[60:63], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v163 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[144:147], v[64:67], a[144:147], v160, v155 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[144:147], v[68:71], a[148:151], v160, v155 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v163 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[148:151], v[64:67], a[152:155], v160, v155 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[148:151], v[68:71], a[156:159], v160, v155 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v163 offset:4800                    
+	ds_read_b32 v153, v166 offset:256                          
+	s_cbranch_scc0 label_0995                                  
+	s_branch label_0632                                        
+	
+label_0995:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xa0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0C29                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v186, 0, v182                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 64, v182                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 0x80, v182                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 0xc0, v182                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_add_u32_e32 v186, 0x100, v182                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_branch label_0EC1                                        
+	
+label_0C29:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0, v182                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 64, v182                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0x80, v182                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0xc0, v182                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0EC1                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v186, 0x100, v182                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v186, s[4:7], 0 offen       
+	v_add_u32_e32 v186, s62, v186                              
+	
+label_0EC1:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x640_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2189,7 +2189,7 @@ label_1137:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2636,14 +2636,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA.s
@@ -1,0 +1,2654 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x2ff                                  
+	s_mov_b32 s63, 0x300                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v180, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v180, v5, v180                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v180, v6, v180                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v180, v4, v180                               
+	v_add_u32_e32 v180, 0x800, v180                            
+	v_add_u32_e32 v181, 0x2100, v180                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v182, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v182, s63, v182                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	v_add_u32_e32 v183, 0, v183                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v184, 4, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v184, s62, v184                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v185, s62, v184                              
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	v_add_u32_e32 v193, s62, v192                              
+	v_add_u32_e32 v194, s62, v193                              
+	v_add_u32_e32 v195, s62, v194                              
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v196, 2, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v196, s63, v196                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v172, v196, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v173, v197, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v174, v198, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v180                                 
+	ds_read_b128 v[16:19], v180 offset:64                      
+	ds_read_b128 v[12:15], v180 offset:512                     
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x300                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xc0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v202, s36, v5                                 
+	v_add_u32_e32 v202, s62, v202                              
+	v_add_u32_e32 v202, v4, v202                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_070B                                  
+	
+label_0312:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[24:27], a[96:99], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[28:31], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[24:27], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[28:31], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[32:35], a[96:99], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[36:39], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[32:35], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[36:39], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[24:27], a[112:115], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[28:31], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[24:27], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[28:31], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[32:35], a[112:115], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[36:39], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[32:35], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[36:39], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[24:27], a[128:131], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[28:31], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[24:27], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[28:31], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[32:35], a[128:131], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[36:39], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[32:35], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[36:39], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[24:27], a[144:147], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[28:31], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[24:27], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[28:31], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[32:35], a[144:147], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[36:39], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[32:35], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[36:39], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[24:27], a[160:163], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[28:31], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[24:27], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[28:31], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[32:35], a[160:163], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[36:39], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[32:35], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[36:39], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[24:27], a[176:179], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[28:31], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[24:27], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[28:31], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[32:35], a[176:179], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[36:39], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[32:35], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[36:39], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_0B04                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[56:59], a[128:131], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[60:63], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[56:59], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[60:63], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[64:67], a[128:131], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[68:71], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[64:67], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[68:71], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_0B04                                  
+	s_branch label_0312                                        
+	
+label_070B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[24:27], a[96:99], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[28:31], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[24:27], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[28:31], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[32:35], a[96:99], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[36:39], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[32:35], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[36:39], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[24:27], a[112:115], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[28:31], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[24:27], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[28:31], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[32:35], a[112:115], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[36:39], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[32:35], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[36:39], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[24:27], a[128:131], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[28:31], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[24:27], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[28:31], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[32:35], a[128:131], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[36:39], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[32:35], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[36:39], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[24:27], a[144:147], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[28:31], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[24:27], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[28:31], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[32:35], a[144:147], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[36:39], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[32:35], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[36:39], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[24:27], a[160:163], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[28:31], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[24:27], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[28:31], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[32:35], a[160:163], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[36:39], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[32:35], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[36:39], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[24:27], a[176:179], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[28:31], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[24:27], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[28:31], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[32:35], a[176:179], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[36:39], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[32:35], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[36:39], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_0B04                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[56:59], a[128:131], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[60:63], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[56:59], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[60:63], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[64:67], a[128:131], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[68:71], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[64:67], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[68:71], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_0B04                                  
+	s_branch label_070B                                        
+	
+label_0B04:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xc0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0E1A                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v206, 0, v202                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 64, v202                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0x80, v202                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0xc0, v202                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0x100, v202                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0x140, v202                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_branch label_1137                                        
+	
+label_0E1A:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0, v202                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 64, v202                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0x80, v202                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0xc0, v202                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0x100, v202                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0x140, v202                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	
+label_1137:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB.s
@@ -1,0 +1,2654 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x2ff                                  
+	s_mov_b32 s63, 0x300                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v180, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v180, v5, v180                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v180, v6, v180                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v180, v4, v180                               
+	v_add_u32_e32 v180, 0x800, v180                            
+	v_add_u32_e32 v181, 0x2100, v180                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v182, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v182, s63, v182                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	v_add_u32_e32 v183, 0, v183                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v184, 4, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v184, s62, v184                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v185, s62, v184                              
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	v_add_u32_e32 v193, s62, v192                              
+	v_add_u32_e32 v194, s62, v193                              
+	v_add_u32_e32 v195, s62, v194                              
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x300                                    
+	s_cselect_b32 s62, s63, 0x300                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v196, 2, v0                              
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v196, s63, v196                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v197, s62, v196                              
+	v_add_u32_e32 v198, s62, v197                              
+	v_add_u32_e32 v199, s62, v198                              
+	v_add_u32_e32 v200, s62, v199                              
+	v_add_u32_e32 v201, s62, v200                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v172, v196, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v173, v197, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v174, v198, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v180                                 
+	ds_read_b128 v[16:19], v180 offset:64                      
+	ds_read_b128 v[12:15], v180 offset:512                     
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x300                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xc0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v202, s36, v5                                 
+	v_add_u32_e32 v202, s62, v202                              
+	v_add_u32_e32 v202, v4, v202                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_070B                                  
+	
+label_0312:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[24:27], a[96:99], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[28:31], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[24:27], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[28:31], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[32:35], a[96:99], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[36:39], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[32:35], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[36:39], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[24:27], a[112:115], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[28:31], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[24:27], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[28:31], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[32:35], a[112:115], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[36:39], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[32:35], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[36:39], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[24:27], a[128:131], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[28:31], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[24:27], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[28:31], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[32:35], a[128:131], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[36:39], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[32:35], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[36:39], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[24:27], a[144:147], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[28:31], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[24:27], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[28:31], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[32:35], a[144:147], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[36:39], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[32:35], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[36:39], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[24:27], a[160:163], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[28:31], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[24:27], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[28:31], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[32:35], a[160:163], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[36:39], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[32:35], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[36:39], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[24:27], a[176:179], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[28:31], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[24:27], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[28:31], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[32:35], a[176:179], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[36:39], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[32:35], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[36:39], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_0B04                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[56:59], a[128:131], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[60:63], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[56:59], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[60:63], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[64:67], a[128:131], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[68:71], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[64:67], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[68:71], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_0B04                                  
+	s_branch label_0312                                        
+	
+label_070B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v172, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v172, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v172, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v172, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v172, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[24:27], a[96:99], v172, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[28:31], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[24:27], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[28:31], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[32:35], a[96:99], v172, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[36:39], a[100:103], v172, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[32:35], a[104:107], v172, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[36:39], a[108:111], v172, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v173, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v173, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v173, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v173, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v173, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[24:27], a[112:115], v173, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[28:31], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[24:27], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[28:31], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[32:35], a[112:115], v173, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[36:39], a[116:119], v173, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[32:35], a[120:123], v173, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[36:39], a[124:127], v173, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[24:27], a[128:131], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[28:31], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[24:27], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[28:31], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[32:35], a[128:131], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[36:39], a[132:135], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[32:35], a[136:139], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[36:39], a[140:143], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[24:27], a[144:147], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[28:31], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[24:27], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[28:31], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[32:35], a[144:147], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[36:39], a[148:151], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[32:35], a[152:155], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[36:39], a[156:159], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[24:27], a[160:163], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[28:31], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[24:27], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[28:31], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[32:35], a[160:163], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[36:39], a[164:167], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[32:35], a[168:171], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[36:39], a[172:175], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v181                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:576                     
+	ds_read_b32 v170, v183 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[24:27], a[176:179], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[28:31], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[24:27], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[28:31], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[32:35], a[176:179], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[36:39], a[180:183], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[32:35], a[184:187], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[36:39], a[188:191], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v181 offset:4800                    
+	ds_read_b32 v171, v183 offset:1280                         
+	s_cbranch_scc0 label_0B04                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v172, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v172, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v172, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v172, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v172, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[72:75], v[56:59], a[96:99], v172, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v199, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[72:75], v[60:63], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[76:79], v[56:59], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[76:79], v[60:63], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[80:83], v[64:67], a[96:99], v172, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[80:83], v[68:71], a[100:103], v172, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[84:87], v[64:67], a[104:107], v172, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[84:87], v[68:71], a[108:111], v172, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v173, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v193, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v173, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v173, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v173, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v193, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v173, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[88:91], v[56:59], a[112:115], v173, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v200, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[88:91], v[60:63], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[92:95], v[56:59], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[92:95], v[60:63], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[96:99], v[64:67], a[112:115], v173, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[96:99], v[68:71], a[116:119], v173, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[100:103], v[64:67], a[120:123], v173, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[100:103], v[68:71], a[124:127], v173, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v194, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v195, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v194, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v195, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[56:59], a[128:131], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v201, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[60:63], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[56:59], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[60:63], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[64:67], a[128:131], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v182, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[68:71], a[132:135], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[64:67], a[136:139], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[68:71], a[140:143], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v184, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v185, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[56:59], a[144:147], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v184, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[60:63], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[56:59], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[60:63], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[64:67], a[144:147], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v172, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[68:71], a[148:151], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[64:67], a[152:155], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[68:71], a[156:159], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v186, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v187, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[56:59], a[160:163], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v173, v197, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[60:63], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[56:59], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[60:63], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[64:67], a[160:163], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[68:71], a[164:167], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[64:67], a[168:171], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[68:71], a[172:175], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v180                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v180 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v180 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v180 offset:576                     
+	ds_read_b32 v168, v183                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[56:59], a[176:179], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v198, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[60:63], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v180 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[56:59], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[60:63], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v180 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[64:67], a[176:179], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[68:71], a[180:183], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v180 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[64:67], a[184:187], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[68:71], a[188:191], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v180 offset:4800                    
+	ds_read_b32 v169, v183 offset:256                          
+	s_cbranch_scc0 label_0B04                                  
+	s_branch label_070B                                        
+	
+label_0B04:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x300                                  
+	s_mul_i32 s63, s46, 0xc0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xc0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0E1A                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v206, 0, v202                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 64, v202                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0x80, v202                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0xc0, v202                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0x100, v202                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_add_u32_e32 v206, 0x140, v202                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_branch label_1137                                        
+	
+label_0E1A:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0, v202                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 64, v202                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0x80, v202                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0xc0, v202                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0x100, v202                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_1137                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v206, 0x140, v202                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v206, s[4:7], 0 offen       
+	v_add_u32_e32 v206, s62, v206                              
+	
+label_1137:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x768_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2469,7 +2469,7 @@ label_13AD:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2916,14 +2916,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA.s
@@ -1,0 +1,2934 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x37f                                  
+	s_mov_b32 s63, 0x380                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v197, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v197, v5, v197                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v197, v6, v197                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v197, v4, v197                               
+	v_add_u32_e32 v197, 0x800, v197                            
+	v_add_u32_e32 v198, 0x2100, v197                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v199, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v199, s63, v199                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v200, 2, v0                              
+	v_add_u32_e32 v200, 0, v200                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v201, 4, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v201, s62, v201                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v202, s62, v201                              
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v215, 2, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v215, s63, v215                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v188, v215, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v189, v216, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v190, v217, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v197                                 
+	ds_read_b128 v[16:19], v197 offset:64                      
+	ds_read_b128 v[12:15], v197 offset:512                     
+	ds_read_b128 v[20:23], v197 offset:576                     
+	ds_read_b32 v184, v200                                     
+	ds_read_b128 v[24:27], v197 offset:4224                    
+	ds_read_b128 v[32:35], v197 offset:4288                    
+	ds_read_b128 v[28:31], v197 offset:4736                    
+	ds_read_b128 v[36:39], v197 offset:4800                    
+	ds_read_b32 v185, v200 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x380                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xe0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v222, s36, v5                                 
+	v_add_u32_e32 v222, s62, v222                              
+	v_add_u32_e32 v222, v4, v222                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_07E4                                  
+	
+label_0355:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[24:27], a[112:115], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[28:31], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[24:27], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[28:31], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[32:35], a[112:115], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[36:39], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[32:35], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[36:39], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[24:27], a[128:131], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[28:31], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[24:27], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[28:31], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[32:35], a[128:131], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[36:39], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[32:35], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[36:39], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[24:27], a[144:147], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[28:31], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[24:27], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[28:31], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[32:35], a[144:147], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[36:39], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[32:35], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[36:39], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[24:27], a[160:163], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[28:31], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[24:27], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[28:31], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[32:35], a[160:163], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[36:39], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[32:35], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[36:39], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[24:27], a[176:179], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[28:31], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[24:27], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[28:31], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[32:35], a[176:179], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[36:39], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[32:35], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[36:39], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[24:27], a[192:195], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[28:31], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[24:27], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[28:31], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[32:35], a[192:195], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[36:39], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[32:35], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[36:39], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	ds_read_b32 v186, v200 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[24:27], a[208:211], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[28:31], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[24:27], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[28:31], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[32:35], a[208:211], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[36:39], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[32:35], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v198 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[36:39], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v200 offset:1280                         
+	s_cbranch_scc0 label_0C73                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[56:59], a[112:115], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[60:63], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[56:59], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[60:63], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[64:67], a[112:115], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[68:71], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[64:67], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[68:71], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[56:59], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[60:63], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[64:67], a[128:131], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[68:71], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[64:67], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[68:71], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[56:59], a[144:147], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[60:63], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[56:59], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[60:63], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[64:67], a[144:147], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[68:71], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[64:67], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[68:71], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[56:59], a[160:163], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[60:63], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[56:59], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[60:63], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[64:67], a[160:163], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[68:71], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[64:67], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[68:71], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[56:59], a[176:179], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[60:63], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[56:59], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[60:63], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[64:67], a[176:179], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[68:71], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[64:67], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[68:71], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[56:59], a[192:195], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[60:63], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[56:59], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[60:63], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[64:67], a[192:195], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[68:71], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[64:67], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[68:71], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v197                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v197 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	ds_read_b32 v184, v200                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[56:59], a[208:211], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v197 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[60:63], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[56:59], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[60:63], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[64:67], a[208:211], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[68:71], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[64:67], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[68:71], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v200 offset:256                          
+	s_cbranch_scc0 label_0C73                                  
+	s_branch label_0355                                        
+	
+label_07E4:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[24:27], a[112:115], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[28:31], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[24:27], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[28:31], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[32:35], a[112:115], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[36:39], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[32:35], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[36:39], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[24:27], a[128:131], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[28:31], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[24:27], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[28:31], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[32:35], a[128:131], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[36:39], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[32:35], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[36:39], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[24:27], a[144:147], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[28:31], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[24:27], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[28:31], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[32:35], a[144:147], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[36:39], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[32:35], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[36:39], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[24:27], a[160:163], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[28:31], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[24:27], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[28:31], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[32:35], a[160:163], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[36:39], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[32:35], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[36:39], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[24:27], a[176:179], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[28:31], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[24:27], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[28:31], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[32:35], a[176:179], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[36:39], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[32:35], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[36:39], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[24:27], a[192:195], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[28:31], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[24:27], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[28:31], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[32:35], a[192:195], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[36:39], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[32:35], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[36:39], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	ds_read_b32 v186, v200 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[24:27], a[208:211], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[28:31], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[24:27], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[28:31], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[32:35], a[208:211], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[36:39], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[32:35], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[36:39], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v198 offset:4800                    
+	ds_read_b32 v187, v200 offset:1280                         
+	s_cbranch_scc0 label_0C73                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[56:59], a[112:115], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[60:63], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[56:59], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[60:63], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[64:67], a[112:115], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[68:71], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[64:67], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[68:71], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[56:59], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[60:63], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[64:67], a[128:131], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[68:71], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[64:67], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[68:71], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[56:59], a[144:147], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[60:63], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[56:59], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[60:63], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[64:67], a[144:147], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[68:71], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[64:67], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[68:71], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[56:59], a[160:163], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[60:63], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[56:59], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[60:63], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[64:67], a[160:163], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[68:71], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[64:67], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[68:71], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[56:59], a[176:179], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[60:63], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[56:59], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[60:63], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[64:67], a[176:179], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[68:71], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[64:67], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[68:71], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[56:59], a[192:195], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[60:63], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[56:59], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[60:63], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[64:67], a[192:195], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[68:71], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[64:67], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[68:71], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v197                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v197 offset:576                     
+	ds_read_b32 v184, v200                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[56:59], a[208:211], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[60:63], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v197 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[56:59], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[60:63], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[64:67], a[208:211], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[68:71], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[64:67], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[68:71], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:4800                    
+	ds_read_b32 v185, v200 offset:256                          
+	s_cbranch_scc0 label_0C73                                  
+	s_branch label_07E4                                        
+	
+label_0C73:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xe0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_100B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v226, 0, v222                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 64, v222                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x80, v222                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0xc0, v222                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x100, v222                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x140, v222                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x180, v222                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_branch label_13AD                                        
+	
+label_100B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0, v222                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 64, v222                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x80, v222                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0xc0, v222                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x100, v222                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x140, v222                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x180, v222                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	
+label_13AD:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB.s
@@ -1,0 +1,2934 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x37f                                  
+	s_mov_b32 s63, 0x380                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 63                                     
+	s_lshr_b32 s62, s51, 6                                     
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0058:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0058                                        
+	
+label_005D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0063                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0083                                        
+	
+label_0063:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0083:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v197, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v197, v5, v197                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v197, v6, v197                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v197, v4, v197                               
+	v_add_u32_e32 v197, 0x800, v197                            
+	v_add_u32_e32 v198, 0x2100, v197                           
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 64                                       
+	s_cselect_b32 s62, s63, 64                                 
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v199, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v199, s63, v199                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v200, 2, v0                              
+	v_add_u32_e32 v200, 0, v200                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v201, 4, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v201, s62, v201                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v202, s62, v201                              
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	v_add_u32_e32 v212, s62, v211                              
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x380                                    
+	s_cselect_b32 s62, s63, 0x380                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v215, 2, v0                              
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v215, s63, v215                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v216, s62, v215                              
+	v_add_u32_e32 v217, s62, v216                              
+	v_add_u32_e32 v218, s62, v217                              
+	v_add_u32_e32 v219, s62, v218                              
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v188, v215, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen nt      
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dword v189, v216, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dword v190, v217, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v197                                 
+	ds_read_b128 v[16:19], v197 offset:64                      
+	ds_read_b128 v[12:15], v197 offset:512                     
+	ds_read_b128 v[20:23], v197 offset:576                     
+	ds_read_b32 v184, v200                                     
+	ds_read_b128 v[24:27], v197 offset:4224                    
+	ds_read_b128 v[32:35], v197 offset:4288                    
+	ds_read_b128 v[28:31], v197 offset:4736                    
+	ds_read_b128 v[36:39], v197 offset:4800                    
+	ds_read_b32 v185, v200 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 64                                     
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x380                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 64                                       
+	s_cselect_b32 s62, s62, 64                                 
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xe0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v222, s36, v5                                 
+	v_add_u32_e32 v222, s62, v222                              
+	v_add_u32_e32 v222, v4, v222                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_07E4                                  
+	
+label_0355:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[24:27], a[112:115], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[28:31], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[24:27], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[28:31], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[32:35], a[112:115], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[36:39], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[32:35], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[36:39], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[24:27], a[128:131], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[28:31], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[24:27], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[28:31], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[32:35], a[128:131], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[36:39], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[32:35], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[36:39], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[24:27], a[144:147], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[28:31], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[24:27], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[28:31], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[32:35], a[144:147], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[36:39], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[32:35], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[36:39], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[24:27], a[160:163], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[28:31], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[24:27], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[28:31], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[32:35], a[160:163], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[36:39], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[32:35], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[36:39], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[24:27], a[176:179], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[28:31], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[24:27], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[28:31], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[32:35], a[176:179], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[36:39], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[32:35], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[36:39], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[24:27], a[192:195], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[28:31], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[24:27], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[28:31], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[32:35], a[192:195], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[36:39], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[32:35], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[36:39], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	ds_read_b32 v186, v200 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[24:27], a[208:211], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[28:31], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[24:27], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[28:31], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[32:35], a[208:211], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[36:39], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[32:35], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v198 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[36:39], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v200 offset:1280                         
+	s_cbranch_scc0 label_0C73                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[56:59], a[112:115], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[60:63], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[56:59], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[60:63], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[64:67], a[112:115], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[68:71], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[64:67], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[68:71], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[56:59], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[60:63], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[64:67], a[128:131], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[68:71], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[64:67], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[68:71], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[56:59], a[144:147], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[60:63], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[56:59], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[60:63], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[64:67], a[144:147], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[68:71], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[64:67], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[68:71], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[56:59], a[160:163], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[60:63], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[56:59], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[60:63], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[64:67], a[160:163], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[68:71], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[64:67], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[68:71], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[56:59], a[176:179], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[60:63], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[56:59], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[60:63], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[64:67], a[176:179], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[68:71], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[64:67], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[68:71], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[56:59], a[192:195], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[60:63], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[56:59], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[60:63], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[64:67], a[192:195], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[68:71], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[64:67], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[68:71], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[8:11], v197                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v197 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	ds_read_b32 v184, v200                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[56:59], a[208:211], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v197 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[60:63], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[56:59], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[60:63], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[64:67], a[208:211], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[68:71], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[64:67], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[68:71], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v200 offset:256                          
+	s_cbranch_scc0 label_0C73                                  
+	s_branch label_0355                                        
+	
+label_07E4:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[8:11], a[0:3], v188, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[12:15], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[8:11], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[12:15], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[16:19], a[0:3], v188, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[20:23], a[4:7], v188, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[16:19], a[8:11], v188, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[20:23], a[12:15], v188, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[24:27], a[112:115], v188, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[28:31], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[24:27], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[28:31], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[32:35], a[112:115], v188, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[36:39], a[116:119], v188, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[32:35], a[120:123], v188, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[36:39], a[124:127], v188, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[8:11], a[16:19], v189, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[12:15], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[8:11], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[12:15], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[16:19], a[16:19], v189, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[20:23], a[20:23], v189, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[16:19], a[24:27], v189, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[20:23], a[28:31], v189, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[24:27], a[128:131], v189, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[28:31], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[24:27], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[28:31], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[32:35], a[128:131], v189, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[36:39], a[132:135], v189, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[32:35], a[136:139], v189, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[36:39], a[140:143], v189, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[8:11], a[32:35], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[12:15], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[8:11], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[12:15], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[16:19], a[32:35], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[20:23], a[36:39], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[16:19], a[40:43], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[20:23], a[44:47], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[24:27], a[144:147], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[28:31], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[24:27], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[28:31], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[32:35], a[144:147], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[36:39], a[148:151], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[32:35], a[152:155], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[36:39], a[156:159], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[8:11], a[48:51], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[12:15], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[8:11], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[12:15], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[16:19], a[48:51], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[20:23], a[52:55], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[16:19], a[56:59], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[20:23], a[60:63], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[24:27], a[160:163], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[28:31], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[24:27], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[28:31], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[32:35], a[160:163], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[36:39], a[164:167], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[32:35], a[168:171], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[36:39], a[172:175], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[8:11], a[64:67], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[12:15], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[8:11], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[12:15], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[16:19], a[64:67], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[20:23], a[68:71], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[16:19], a[72:75], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[20:23], a[76:79], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[24:27], a[176:179], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[28:31], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[24:27], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[28:31], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[32:35], a[176:179], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[36:39], a[180:183], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[32:35], a[184:187], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[36:39], a[188:191], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[8:11], a[80:83], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[12:15], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[8:11], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[12:15], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[16:19], a[80:83], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[20:23], a[84:87], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[16:19], a[88:91], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[20:23], a[92:95], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[24:27], a[192:195], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[28:31], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[24:27], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[28:31], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[32:35], a[192:195], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[36:39], a[196:199], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[32:35], a[200:203], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[36:39], a[204:207], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[8:11], a[96:99], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[12:15], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[40:43], v198                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[8:11], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[12:15], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[16:19], a[96:99], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[20:23], a[100:103], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[16:19], a[104:107], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[20:23], a[108:111], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:576                     
+	ds_read_b32 v186, v200 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[24:27], a[208:211], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[28:31], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[24:27], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[28:31], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[32:35], a[208:211], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[36:39], a[212:215], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[32:35], a[216:219], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[36:39], a[220:223], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v198 offset:4800                    
+	ds_read_b32 v187, v200 offset:1280                         
+	s_cbranch_scc0 label_0C73                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[72:75], v[40:43], a[0:3], v188, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[120:123], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[72:75], v[44:47], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[76:79], v[40:43], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[76:79], v[44:47], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[80:83], v[48:51], a[0:3], v188, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[80:83], v[52:55], a[4:7], v188, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[84:87], v[48:51], a[8:11], v188, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[84:87], v[52:55], a[12:15], v188, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[72:75], v[56:59], a[112:115], v188, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v218, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[72:75], v[60:63], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[76:79], v[56:59], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[76:79], v[60:63], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[80:83], v[64:67], a[112:115], v188, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[80:83], v[68:71], a[116:119], v188, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[84:87], v[64:67], a[120:123], v188, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[84:87], v[68:71], a[124:127], v188, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[88:91], v[40:43], a[16:19], v189, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[88:91], v[44:47], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[92:95], v[40:43], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[92:95], v[44:47], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[96:99], v[48:51], a[16:19], v189, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[96:99], v[52:55], a[20:23], v189, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[100:103], v[48:51], a[24:27], v189, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[100:103], v[52:55], a[28:31], v189, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[88:91], v[56:59], a[128:131], v189, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v219, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[88:91], v[60:63], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[92:95], v[56:59], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[92:95], v[60:63], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[96:99], v[64:67], a[128:131], v189, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[96:99], v[68:71], a[132:135], v189, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[100:103], v[64:67], a[136:139], v189, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[100:103], v[68:71], a[140:143], v189, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v212, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v212, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[104:107], v[56:59], a[144:147], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v220, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[104:107], v[60:63], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[108:111], v[56:59], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[108:111], v[60:63], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[112:115], v[64:67], a[144:147], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[112:115], v[68:71], a[148:151], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[116:119], v[64:67], a[152:155], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[116:119], v[68:71], a[156:159], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[40:43], a[48:51], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v213, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[44:47], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[40:43], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[172:175], v214, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[44:47], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[48:51], a[48:51], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v213, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[52:55], a[52:55], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[48:51], a[56:59], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v214, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[52:55], a[60:63], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[120:123], v[56:59], a[160:163], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v221, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[120:123], v[60:63], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[124:127], v[56:59], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[124:127], v[60:63], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[128:131], v[64:67], a[160:163], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v199, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[128:131], v[68:71], a[164:167], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[132:135], v[64:67], a[168:171], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[132:135], v[68:71], a[172:175], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[40:43], a[64:67], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[44:47], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[40:43], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[44:47], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[48:51], a[64:67], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[72:75], v201, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[52:55], a[68:71], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[48:51], a[72:75], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[76:79], v202, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[52:55], a[76:79], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[136:139], v[56:59], a[176:179], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[80:83], v201, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[136:139], v[60:63], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[140:143], v[56:59], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[84:87], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[140:143], v[60:63], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[144:147], v[64:67], a[176:179], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v188, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[144:147], v[68:71], a[180:183], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[148:151], v[64:67], a[184:187], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[148:151], v[68:71], a[188:191], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[40:43], a[80:83], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[88:91], v203, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[44:47], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[40:43], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[92:95], v204, s[16:19], 0 offen nt      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[44:47], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[48:51], a[80:83], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[96:99], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[52:55], a[84:87], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[48:51], a[88:91], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[100:103], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[52:55], a[92:95], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[152:155], v[56:59], a[192:195], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v189, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[152:155], v[60:63], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[156:159], v[56:59], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[156:159], v[60:63], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[160:163], v[64:67], a[192:195], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[160:163], v[68:71], a[196:199], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[164:167], v[64:67], a[200:203], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[164:167], v[68:71], a[204:207], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[168:171], v[40:43], a[96:99], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[104:107], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[168:171], v[44:47], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[8:11], v197                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[172:175], v[40:43], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[172:175], v[44:47], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v197 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[176:179], v[48:51], a[96:99], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[176:179], v[52:55], a[100:103], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v197 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[180:183], v[48:51], a[104:107], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[180:183], v[52:55], a[108:111], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v197 offset:576                     
+	ds_read_b32 v184, v200                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[168:171], v[56:59], a[208:211], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v217, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[168:171], v[60:63], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v197 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[172:175], v[56:59], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[172:175], v[60:63], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v197 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[176:179], v[64:67], a[208:211], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[176:179], v[68:71], a[212:215], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v197 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[180:183], v[64:67], a[216:219], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[180:183], v[68:71], a[220:223], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v197 offset:4800                    
+	ds_read_b32 v185, v200 offset:256                          
+	s_cbranch_scc0 label_0C73                                  
+	s_branch label_07E4                                        
+	
+label_0C73:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x380                                  
+	s_mul_i32 s63, s46, 0xe0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xe0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_100B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v226, 0, v222                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 64, v222                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x80, v222                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0xc0, v222                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x100, v222                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x140, v222                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_add_u32_e32 v226, 0x180, v222                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_branch label_13AD                                        
+	
+label_100B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0, v222                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 64, v222                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x80, v222                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0xc0, v222                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x100, v222                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x140, v222                            
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_13AD                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v226, 0x180, v222                            
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v226, s[4:7], 0 offen       
+	v_add_u32_e32 v226, s62, v226                              
+	
+label_13AD:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_64x896_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1339,7 +1339,7 @@ label_0987:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -1786,14 +1786,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA.s
@@ -1,0 +1,1804 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v181, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v181, v5, v181                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v181, v6, v181                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v181, v4, v181                               
+	v_add_u32_e32 v181, 0x1000, v181                           
+	v_add_u32_e32 v182, 0x3180, v181                           
+	v_add_u32_e32 v183, 0x3180, v182                           
+	v_add_u32_e32 v184, 0x3180, v183                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v185, s63, v185                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v186, 2, v0                              
+	v_add_u32_e32 v186, 0, v186                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v187, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v187, s62, v187                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v188, s62, v187                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v189, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v189, s63, v189                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v174, v189, s[24:27], 0 offen            
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v189, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v189, s[24:27], 0 offen            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(24)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v181                                 
+	ds_read_b128 v[16:19], v181 offset:64                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v190, s36, v5                                 
+	v_add_u32_e32 v190, s62, v190                              
+	v_add_u32_e32 v190, v4, v190                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0520                                  
+	
+label_0249:
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[156:159], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[160:163], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[164:167], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v186 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v177, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v172, v186 offset:1280                         
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[72:75], a[16:19], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[76:79], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[72:75], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[76:79], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[80:83], a[16:19], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[84:87], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[80:83], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[20:23], v183 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[84:87], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v186 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[88:91], a[32:35], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[92:95], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v174, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[88:91], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[92:95], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[96:99], a[32:35], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[100:103], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[96:99], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[100:103], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v169, v186 offset:2304                         
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[68:71], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v186 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v175, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v172, v186 offset:3328                         
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[72:75], a[16:19], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[76:79], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[72:75], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[76:79], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[80:83], a[16:19], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[84:87], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[80:83], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[20:23], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[84:87], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v186                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[88:91], a[32:35], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[92:95], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v176, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[88:91], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[92:95], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[96:99], a[32:35], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[100:103], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[96:99], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[100:103], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v169, v186 offset:256                          
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_branch label_0249                                        
+	
+label_0520:
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[156:159], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[160:163], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[164:167], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v186 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v177, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	ds_read_b32 v172, v186 offset:1280                         
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[72:75], a[16:19], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[76:79], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[72:75], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[76:79], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[80:83], a[16:19], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[84:87], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[80:83], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[84:87], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[20:23], v183 offset:576                     
+	ds_read_b32 v168, v186 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[88:91], a[32:35], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v174, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[92:95], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[88:91], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[92:95], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[96:99], a[32:35], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[100:103], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[96:99], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[100:103], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	ds_read_b32 v169, v186 offset:2304                         
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v184 offset:576                     
+	ds_read_b32 v171, v186 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v175, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	ds_read_b32 v172, v186 offset:3328                         
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[72:75], a[16:19], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[76:79], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[72:75], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[76:79], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[80:83], a[16:19], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[84:87], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[80:83], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[84:87], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[88:91], a[32:35], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v176, v189, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[92:95], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[88:91], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[92:95], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[96:99], a[32:35], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[100:103], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[96:99], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[100:103], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_branch label_0520                                        
+	
+label_07F7:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_08C2                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v194, 0, v190                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	s_branch label_0987                                        
+	
+label_08C2:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0987                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v194, 0, v190                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	
+label_0987:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB.s
@@ -1,0 +1,1804 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x7f                                   
+	s_lshr_b32 s50, s51, 7                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v181, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v181, v5, v181                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v181, v6, v181                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v181, v4, v181                               
+	v_add_u32_e32 v181, 0x1000, v181                           
+	v_add_u32_e32 v182, 0x3180, v181                           
+	v_add_u32_e32 v183, 0x3180, v182                           
+	v_add_u32_e32 v184, 0x3180, v183                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v185, s63, v185                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v186, 2, v0                              
+	v_add_u32_e32 v186, 0, v186                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v187, 4, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v187, s62, v187                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v188, s62, v187                              
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x80                                     
+	s_cselect_b32 s62, s63, 0x80                               
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v189, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v189, s63, v189                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v174, v189, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v175, v189, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v189, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_add_u32 s63, 0x300, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_waitcnt vmcnt(24)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v181                                 
+	ds_read_b128 v[16:19], v181 offset:64                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x80                                   
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 32                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v190, s36, v5                                 
+	v_add_u32_e32 v190, s62, v190                              
+	v_add_u32_e32 v190, v4, v190                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0520                                  
+	
+label_0249:
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[156:159], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[160:163], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[164:167], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v186 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v177, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v172, v186 offset:1280                         
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[72:75], a[16:19], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[76:79], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[72:75], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[76:79], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[80:83], a[16:19], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[84:87], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[80:83], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[20:23], v183 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[84:87], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v186 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[88:91], a[32:35], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[92:95], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v174, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[88:91], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[92:95], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[96:99], a[32:35], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[100:103], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[96:99], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[100:103], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v169, v186 offset:2304                         
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[68:71], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v171, v186 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v175, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v172, v186 offset:3328                         
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[72:75], a[16:19], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[76:79], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[72:75], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[76:79], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[80:83], a[16:19], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[84:87], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[80:83], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[20:23], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[84:87], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	ds_read_b32 v168, v186                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[88:91], a[32:35], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[92:95], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v176, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[88:91], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[92:95], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[96:99], a[32:35], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[100:103], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[96:99], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[100:103], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	ds_read_b32 v169, v186 offset:256                          
+	s_sub_u32 s26, s26, s69                                    
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_branch label_0249                                        
+	
+label_0520:
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[104:107], v[24:27], a[16:19], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[152:155], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[104:107], v[28:31], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[108:111], v[24:27], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[156:159], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[108:111], v[28:31], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[112:115], v[32:35], a[16:19], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[160:163], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[112:115], v[36:39], a[20:23], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[116:119], v[32:35], a[24:27], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[164:167], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[116:119], v[36:39], a[28:31], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v186 offset:1024                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[40:43], a[32:35], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v177, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[44:47], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[40:43], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[44:47], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[48:51], a[32:35], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[52:55], a[36:39], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[48:51], a[40:43], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[52:55], a[44:47], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	ds_read_b32 v172, v186 offset:1280                         
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[120:123], v[56:59], a[0:3], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[120:123], v[60:63], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[124:127], v[56:59], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[124:127], v[60:63], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[128:131], v[64:67], a[0:3], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[128:131], v[68:71], a[4:7], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[132:135], v[64:67], a[8:11], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[132:135], v[68:71], a[12:15], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[72:75], a[16:19], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[76:79], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[72:75], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[76:79], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[80:83], a[16:19], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[84:87], a[20:23], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[80:83], a[24:27], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[84:87], a[28:31], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[20:23], v183 offset:576                     
+	ds_read_b32 v168, v186 offset:2048                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[120:123], v[88:91], a[32:35], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v174, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[120:123], v[92:95], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[124:127], v[88:91], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[124:127], v[92:95], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[128:131], v[96:99], a[32:35], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[128:131], v[100:103], a[36:39], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[132:135], v[96:99], a[40:43], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[132:135], v[100:103], a[44:47], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	ds_read_b32 v169, v186 offset:2304                         
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[8:11], a[0:3], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[12:15], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[8:11], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[12:15], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[16:19], a[0:3], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[20:23], a[4:7], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[16:19], a[8:11], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[20:23], a[12:15], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[136:139], v[24:27], a[16:19], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[136:139], v[28:31], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[140:143], v[24:27], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[140:143], v[28:31], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[144:147], v[32:35], a[16:19], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[144:147], v[36:39], a[20:23], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[148:151], v[32:35], a[24:27], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[148:151], v[36:39], a[28:31], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[68:71], v184 offset:576                     
+	ds_read_b32 v171, v186 offset:3072                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[40:43], a[32:35], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v175, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[44:47], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[40:43], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[44:47], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[48:51], a[32:35], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[52:55], a[36:39], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[48:51], a[40:43], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[52:55], a[44:47], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	ds_read_b32 v172, v186 offset:3328                         
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_waitcnt vmcnt(18) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x400, s60                                  
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt vmcnt(19) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[72:75], a[16:19], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s62, s61                                      
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[76:79], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[72:75], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[76:79], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[80:83], a[16:19], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[84:87], a[20:23], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[80:83], a[24:27], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[84:87], a[28:31], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[152:155], v[88:91], a[32:35], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dword v176, v189, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[152:155], v[92:95], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x400, s60                                  
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[156:159], v[88:91], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[156:159], v[92:95], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[160:163], v[96:99], a[32:35], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[160:163], v[100:103], a[36:39], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[164:167], v[96:99], a[40:43], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[164:167], v[100:103], a[44:47], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s26, s26, s69                                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	s_cbranch_scc0 label_07F7                                  
+	s_branch label_0520                                        
+	
+label_07F7:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x80                                   
+	s_mul_i32 s63, s46, 32                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 32                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_08C2                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v194, 0, v190                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	s_branch label_0987                                        
+	
+label_08C2:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0987                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v194, 0, v190                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v194, s[4:7], 0 offen       
+	v_add_u32_e32 v194, s62, v194                              
+	
+label_0987:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x128_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1834,7 +1834,7 @@ label_0E9F:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2281,14 +2281,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA.s
@@ -1,0 +1,2299 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v181, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v181, v5, v181                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v181, v6, v181                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v181, v4, v181                               
+	v_add_u32_e32 v181, 0x1000, v181                           
+	v_add_u32_e32 v182, 0x3180, v181                           
+	v_add_u32_e32 v183, 0x3180, v182                           
+	v_add_u32_e32 v184, 0x3180, v183                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v185, s63, v185                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v186, 2, v0                              
+	v_add_u32_e32 v186, 0, v186                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v187, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v187, s62, v187                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v191, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v191, s63, v191                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v192, s62, v191                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v174, v191, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(20)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v181                                 
+	ds_read_b128 v[16:19], v181 offset:64                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v193, s36, v5                                 
+	v_add_u32_e32 v193, s62, v193                              
+	v_add_u32_e32 v193, v4, v193                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0703                                  
+	
+label_027C:
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v174, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v186 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v172, v186 offset:1280                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v183 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v186 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v186 offset:2304                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v174, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v186 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v172, v186 offset:3328                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v186                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v186 offset:256                          
+	s_cbranch_scc0 label_0B8A                                  
+	s_branch label_027C                                        
+	
+label_0703:
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v186 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	ds_read_b32 v172, v186 offset:1280                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v183 offset:576                     
+	ds_read_b32 v168, v186 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	ds_read_b32 v169, v186 offset:2304                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:576                     
+	ds_read_b32 v171, v186 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	ds_read_b32 v172, v186 offset:3328                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_cbranch_scc0 label_0B8A                                  
+	s_branch label_0703                                        
+	
+label_0B8A:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0D16                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_branch label_0E9F                                        
+	
+label_0D16:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0E9F                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0E9F                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	
+label_0E9F:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB.s
@@ -1,0 +1,2299 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0xff                                   
+	s_lshr_b32 s50, s51, 8                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x1000, s64                                 
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v181, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v181, v5, v181                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v181, v6, v181                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v181, v4, v181                               
+	v_add_u32_e32 v181, 0x1000, v181                           
+	v_add_u32_e32 v182, 0x3180, v181                           
+	v_add_u32_e32 v183, 0x3180, v182                           
+	v_add_u32_e32 v184, 0x3180, v183                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v185, s63, v185                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v186, 2, v0                              
+	v_add_u32_e32 v186, 0, v186                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v187, 4, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v187, s62, v187                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x100                                    
+	s_cselect_b32 s62, s63, 0x100                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v191, 2, v0                              
+	s_mul_i32 s63, s46, 64                                     
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v191, s63, v191                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v192, s62, v191                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	buffer_load_dword v174, v191, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	s_waitcnt vmcnt(20)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v181                                 
+	ds_read_b128 v[16:19], v181 offset:64                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x100                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 64                                     
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v193, s36, v5                                 
+	v_add_u32_e32 v193, s62, v193                              
+	v_add_u32_e32 v193, v4, v193                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0703                                  
+	
+label_027C:
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v174, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v186 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v172, v186 offset:1280                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v183 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v186 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v186 offset:2304                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v174, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v186 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v172, v186 offset:3328                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v186                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v186 offset:256                          
+	s_cbranch_scc0 label_0B8A                                  
+	s_branch label_027C                                        
+	
+label_0703:
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	ds_read_b32 v170, v186 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x800, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x6300, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x7380, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x8400, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v186 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	ds_read_b32 v172, v186 offset:1280                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	ds_read_b32 v173, v186 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xc00, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x9480, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xa500, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0xb580, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[8:11], v183                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[16:19], v183 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v183 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v183 offset:576                     
+	ds_read_b32 v168, v186 offset:2048                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v183 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v183 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v183 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v183 offset:4800                    
+	ds_read_b32 v169, v186 offset:2304                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[152:155], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v183 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[156:159], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[48:51], v183 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v183 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v183 offset:9024                    
+	ds_read_b32 v170, v186 offset:2560                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[104:107], v[24:27], a[32:35], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[104:107], v[28:31], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[108:111], v[24:27], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[108:111], v[28:31], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[112:115], v[32:35], a[32:35], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[112:115], v[36:39], a[36:39], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[116:119], v[32:35], a[40:43], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[116:119], v[36:39], a[44:47], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[40:43], a[64:67], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[44:47], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[40:43], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[44:47], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[48:51], a[64:67], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[52:55], a[68:71], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[48:51], a[72:75], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[52:55], a[76:79], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[104:107], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[108:111], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[120:123], v[24:27], a[48:51], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[112:115], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[120:123], v[28:31], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[56:59], v184                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[124:127], v[24:27], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[116:119], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[124:127], v[28:31], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[64:67], v184 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[128:131], v[32:35], a[48:51], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[128:131], v[36:39], a[52:55], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v184 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[132:135], v[32:35], a[56:59], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[132:135], v[36:39], a[60:63], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v184 offset:576                     
+	ds_read_b32 v171, v186 offset:3072                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[40:43], a[80:83], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[44:47], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v184 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[40:43], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[44:47], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v184 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[48:51], a[80:83], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[52:55], a[84:87], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v184 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[48:51], a[88:91], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[52:55], a[92:95], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v184 offset:4800                    
+	ds_read_b32 v172, v186 offset:3328                         
+	s_cbranch_scc0 label_0B8A                                  
+	s_waitcnt vmcnt(14) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[136:139], v[56:59], a[0:3], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[120:123], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[136:139], v[60:63], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[88:91], v184 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[140:143], v[56:59], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[124:127], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[140:143], v[60:63], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	ds_read_b128 v[96:99], v184 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[144:147], v[64:67], a[0:3], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[144:147], v[68:71], a[4:7], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v184 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[148:151], v[64:67], a[8:11], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[148:151], v[68:71], a[12:15], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v184 offset:9024                  
+	ds_read_b32 v173, v186 offset:3584                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[72:75], a[32:35], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v192, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[76:79], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[72:75], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[76:79], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[80:83], a[32:35], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v185, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[84:87], a[36:39], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[80:83], a[40:43], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[84:87], a[44:47], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[136:139], v[88:91], a[64:67], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[136:139], v[92:95], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[140:143], v[88:91], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[140:143], v[92:95], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[144:147], v[96:99], a[64:67], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[144:147], v[100:103], a[68:71], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[148:151], v[96:99], a[72:75], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[148:151], v[100:103], a[76:79], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(16)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[152:155], v[56:59], a[16:19], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[152:155], v[60:63], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[156:159], v[56:59], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[156:159], v[60:63], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x300, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[160:163], v[64:67], a[16:19], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[136:139], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[160:163], v[68:71], a[20:23], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[164:167], v[64:67], a[24:27], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[140:143], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[164:167], v[68:71], a[28:31], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_waitcnt vmcnt(17)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[144:147], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[148:151], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v191, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v186                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[152:155], v[88:91], a[80:83], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[152:155], v[92:95], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[156:159], v[88:91], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[156:159], v[92:95], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[160:163], v[96:99], a[80:83], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[160:163], v[100:103], a[84:87], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[164:167], v[96:99], a[88:91], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[164:167], v[100:103], a[92:95], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v186 offset:256                          
+	s_cbranch_scc0 label_0B8A                                  
+	s_branch label_0703                                        
+	
+label_0B8A:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x100                                  
+	s_mul_i32 s63, s46, 64                                     
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 64                                     
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0D16                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_branch label_0E9F                                        
+	
+label_0D16:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0E9F                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 0, v193                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0E9F                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v197, 64, v193                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v197, s[4:7], 0 offen       
+	v_add_u32_e32 v197, s62, v197                              
+	
+label_0E9F:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x256_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -1799,7 +1799,7 @@ label_0DB2:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2246,14 +2246,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA.s
@@ -1,0 +1,2264 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0078:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_007D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0078                                        
+	
+label_007D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0083                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_00A3                                        
+	
+label_0083:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_00A3:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v215, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v215, v5, v215                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v215, v6, v215                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v215, v4, v215                               
+	v_add_u32_e32 v215, 0x800, v215                            
+	v_add_u32_e32 v216, 0x3180, v215                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v217, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v217, s63, v217                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v218, 2, v0                              
+	v_add_u32_e32 v218, 0, v218                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v219, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v219, s62, v219                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v225, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v225, s63, v225                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[104:107], v219, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[108:111], v220, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[112:115], v219, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[116:119], v220, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v206, v225, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v221, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v222, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v221, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v222, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v207, v226, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[136:139], v223, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[140:143], v224, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v223, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[148:151], v224, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v208, v227, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v215                                 
+	ds_read_b128 v[16:19], v215 offset:64                      
+	ds_read_b128 v[12:15], v215 offset:512                     
+	ds_read_b128 v[20:23], v215 offset:576                     
+	ds_read_b32 v200, v218                                     
+	ds_read_b128 v[24:27], v215 offset:4224                    
+	ds_read_b128 v[32:35], v215 offset:4288                    
+	ds_read_b128 v[28:31], v215 offset:4736                    
+	ds_read_b128 v[36:39], v215 offset:4800                    
+	ds_read_b32 v201, v218 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v228, s36, v5                                 
+	v_add_u32_e32 v228, s62, v228                              
+	v_add_u32_e32 v228, v4, v228                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_05FB                                  
+	
+label_02E2:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v215 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v219, s[16:19], 0 offen    
+	ds_read_b32 v202, v218 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v220, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v225, s[24:27], 0 offen            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[40:43], a[96:99], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[44:47], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[40:43], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[44:47], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[48:51], a[96:99], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[52:55], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[48:51], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[52:55], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[168:171], v221, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[172:175], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[176:179], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[24:27], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[28:31], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v226, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[32:35], a[64:67], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[36:39], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[32:35], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[36:39], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[40:43], a[112:115], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[44:47], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[40:43], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[44:47], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[48:51], a[112:115], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[52:55], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[48:51], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[52:55], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v224, s[16:19], 0 offen offset:1024
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[24:27], a[80:83], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[28:31], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v227, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[24:27], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[28:31], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[32:35], a[80:83], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[36:39], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[32:35], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[36:39], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v203, v218 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[40:43], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[44:47], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[48:51], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[52:55], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[48:51], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v216 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[52:55], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v218 offset:1280                         
+	s_cbranch_scc0 label_0914                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v216 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v219, s[16:19], 0 offen    
+	ds_read_b32 v205, v218 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v220, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v225, s[24:27], 0 offen            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[88:91], a[96:99], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[92:95], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[88:91], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[92:95], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[96:99], a[96:99], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[100:103], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[96:99], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[100:103], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[56:59], a[16:19], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[60:63], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[56:59], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[60:63], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v221, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[64:67], a[16:19], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[68:71], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[64:67], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[68:71], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v226, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[88:91], a[112:115], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[92:95], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[88:91], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[92:95], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[96:99], a[112:115], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[100:103], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[96:99], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[100:103], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[56:59], a[32:35], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[60:63], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[56:59], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[60:63], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[64:67], a[32:35], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[68:71], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[64:67], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[68:71], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v224, s[16:19], 0 offen offset:1024
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[72:75], a[80:83], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v215                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[76:79], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v227, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[72:75], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[76:79], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[80:83], a[80:83], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[84:87], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[80:83], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v215 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[84:87], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v200, v218                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[88:91], a[128:131], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[92:95], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[188:191], v[88:91], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[188:191], v[92:95], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[192:195], v[96:99], a[128:131], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[192:195], v[100:103], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[196:199], v[96:99], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v215 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[196:199], v[100:103], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v218 offset:256                          
+	s_cbranch_scc0 label_0914                                  
+	s_branch label_02E2                                        
+	
+label_05FB:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v215 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v219, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:9024                    
+	ds_read_b32 v202, v218 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v220, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v225, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[40:43], a[96:99], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[44:47], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[40:43], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[44:47], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[48:51], a[96:99], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[52:55], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[48:51], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[52:55], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[168:171], v221, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[172:175], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[176:179], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[24:27], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v226, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[28:31], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[32:35], a[64:67], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[36:39], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[32:35], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[36:39], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[40:43], a[112:115], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[44:47], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[40:43], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[44:47], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[48:51], a[112:115], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[52:55], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[48:51], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[52:55], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[184:187], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[24:27], a[80:83], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v227, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[28:31], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[24:27], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[28:31], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[32:35], a[80:83], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[36:39], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[32:35], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[36:39], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:576                     
+	ds_read_b32 v203, v218 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[40:43], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[44:47], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[48:51], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[52:55], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[48:51], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[52:55], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v216 offset:4800                    
+	ds_read_b32 v204, v218 offset:1280                         
+	s_cbranch_scc0 label_0914                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v219, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v216 offset:9024                  
+	ds_read_b32 v205, v218 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v220, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v225, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[88:91], a[96:99], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[92:95], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[88:91], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[92:95], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[96:99], a[96:99], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[100:103], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[96:99], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[100:103], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[56:59], a[16:19], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[60:63], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[56:59], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v221, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[60:63], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[64:67], a[16:19], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v222, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[68:71], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[64:67], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[68:71], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v226, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[88:91], a[112:115], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[92:95], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[88:91], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[92:95], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[96:99], a[112:115], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[100:103], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[96:99], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[100:103], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[56:59], a[32:35], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[136:139], v223, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[60:63], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[56:59], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v224, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[60:63], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[64:67], a[32:35], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[68:71], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[64:67], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[68:71], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[72:75], a[80:83], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v227, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[76:79], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v215                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[72:75], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[76:79], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[80:83], a[80:83], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[84:87], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[80:83], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[84:87], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v215 offset:576                     
+	ds_read_b32 v200, v218                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[88:91], a[128:131], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[92:95], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[188:191], v[88:91], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[188:191], v[92:95], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[192:195], v[96:99], a[128:131], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[192:195], v[100:103], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[196:199], v[96:99], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[196:199], v[100:103], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v215 offset:4800                    
+	ds_read_b32 v201, v218 offset:256                          
+	s_cbranch_scc0 label_0914                                  
+	s_branch label_05FB                                        
+	
+label_0914:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0B64                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v232, 0, v228                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_add_u32_e32 v232, 64, v228                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_add_u32_e32 v232, 0x80, v228                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	s_branch label_0DB2                                        
+	
+label_0B64:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0DB2                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v232, 0, v228                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0DB2                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v232, 64, v228                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0DB2                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v232, 0x80, v228                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	
+label_0DB2:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB.s
@@ -1,0 +1,2264 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x17f                                  
+	s_mov_b32 s63, 0x180                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0078:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_007D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0078                                        
+	
+label_007D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0083                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_00A3                                        
+	
+label_0083:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_00A3:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v212, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v212, v4, v212                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v212, s62, v212                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v215, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v215, v5, v215                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v215, v6, v215                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v215, v4, v215                               
+	v_add_u32_e32 v215, 0x800, v215                            
+	v_add_u32_e32 v216, 0x3180, v215                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v217, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v217, s63, v217                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v218, 2, v0                              
+	v_add_u32_e32 v218, 0, v218                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v219, 4, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v219, s62, v219                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v220, s62, v219                              
+	v_add_u32_e32 v221, s62, v220                              
+	v_add_u32_e32 v222, s62, v221                              
+	v_add_u32_e32 v223, s62, v222                              
+	v_add_u32_e32 v224, s62, v223                              
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x180                                    
+	s_cselect_b32 s62, s63, 0x180                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v225, 2, v0                              
+	s_mul_i32 s63, s46, 0x60                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v225, s63, v225                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v226, s62, v225                              
+	v_add_u32_e32 v227, s62, v226                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[104:107], v219, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[108:111], v220, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[112:115], v219, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[116:119], v220, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v206, v225, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v221, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v222, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v221, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v222, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v207, v226, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[136:139], v223, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[140:143], v224, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v223, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[148:151], v224, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v208, v227, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v215                                 
+	ds_read_b128 v[16:19], v215 offset:64                      
+	ds_read_b128 v[12:15], v215 offset:512                     
+	ds_read_b128 v[20:23], v215 offset:576                     
+	ds_read_b32 v200, v218                                     
+	ds_read_b128 v[24:27], v215 offset:4224                    
+	ds_read_b128 v[32:35], v215 offset:4288                    
+	ds_read_b128 v[28:31], v215 offset:4736                    
+	ds_read_b128 v[36:39], v215 offset:4800                    
+	ds_read_b32 v201, v218 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x180                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x60                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v228, s36, v5                                 
+	v_add_u32_e32 v228, s62, v228                              
+	v_add_u32_e32 v228, v4, v228                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_05FB                                  
+	
+label_02E2:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v215 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v219, s[16:19], 0 offen nt    
+	ds_read_b32 v202, v218 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v220, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v225, s[24:27], 0 offen nt            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[40:43], a[96:99], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[44:47], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[40:43], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[44:47], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[48:51], a[96:99], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[52:55], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[48:51], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[52:55], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[168:171], v221, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[172:175], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[176:179], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[24:27], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[28:31], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v226, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[32:35], a[64:67], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[36:39], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[32:35], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[36:39], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[40:43], a[112:115], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[44:47], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[40:43], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[44:47], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[48:51], a[112:115], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[52:55], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[48:51], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[52:55], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[184:187], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[188:191], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v224, s[16:19], 0 offen offset:1024
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[24:27], a[80:83], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[28:31], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v227, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[24:27], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[28:31], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[32:35], a[80:83], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[36:39], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[32:35], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[68:71], v216 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[36:39], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v203, v218 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[40:43], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[44:47], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[48:51], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[52:55], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[48:51], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v216 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[52:55], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v204, v218 offset:1280                         
+	s_cbranch_scc0 label_0914                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v216 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v219, s[16:19], 0 offen nt    
+	ds_read_b32 v205, v218 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v220, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v225, s[24:27], 0 offen nt            
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[88:91], a[96:99], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[92:95], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[88:91], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[92:95], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[96:99], a[96:99], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[100:103], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[96:99], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[100:103], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[56:59], a[16:19], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[60:63], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[56:59], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[60:63], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v221, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[64:67], a[16:19], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[68:71], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[64:67], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[68:71], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v226, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[88:91], a[112:115], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[92:95], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[88:91], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[92:95], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[96:99], a[112:115], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[100:103], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[96:99], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[100:103], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[56:59], a[32:35], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[60:63], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[136:139], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[56:59], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[60:63], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[64:67], a[32:35], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[68:71], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[64:67], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[68:71], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v224, s[16:19], 0 offen offset:1024
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[72:75], a[80:83], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v215                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[76:79], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v227, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[72:75], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[16:19], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[76:79], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[80:83], a[80:83], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[12:15], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[84:87], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[80:83], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[20:23], v215 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[84:87], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	ds_read_b32 v200, v218                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[88:91], a[128:131], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[92:95], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[188:191], v[88:91], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[188:191], v[92:95], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[192:195], v[96:99], a[128:131], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[192:195], v[100:103], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[196:199], v[96:99], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v215 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[196:199], v[100:103], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v201, v218 offset:256                          
+	s_cbranch_scc0 label_0914                                  
+	s_branch label_02E2                                        
+	
+label_05FB:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v206, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v215 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v215 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v206, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v206, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v215 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v206, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v219, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v206, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v215 offset:9024                    
+	ds_read_b32 v202, v218 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[104:107], v[24:27], a[48:51], v206, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v220, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[104:107], v[28:31], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[108:111], v[24:27], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[108:111], v[28:31], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[112:115], v[32:35], a[48:51], v206, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[112:115], v[36:39], a[52:55], v206, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[116:119], v[32:35], a[56:59], v206, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v209, v225, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[116:119], v[36:39], a[60:63], v206, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[104:107], v[40:43], a[96:99], v206, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[104:107], v[44:47], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[108:111], v[40:43], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[108:111], v[44:47], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[112:115], v[48:51], a[96:99], v206, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[112:115], v[52:55], a[100:103], v206, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[116:119], v[48:51], a[104:107], v206, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[116:119], v[52:55], a[108:111], v206, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v207, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[168:171], v221, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v207, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[172:175], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v207, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v207, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[176:179], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v207, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[120:123], v[24:27], a[64:67], v207, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[120:123], v[28:31], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[124:127], v[24:27], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v210, v226, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[124:127], v[28:31], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[128:131], v[32:35], a[64:67], v207, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[128:131], v[36:39], a[68:71], v207, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[132:135], v[32:35], a[72:75], v207, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[132:135], v[36:39], a[76:79], v207, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[120:123], v[40:43], a[112:115], v207, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[120:123], v[44:47], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[124:127], v[40:43], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[124:127], v[44:47], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[128:131], v[48:51], a[112:115], v207, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[128:131], v[52:55], a[116:119], v207, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[132:135], v[48:51], a[120:123], v207, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[132:135], v[52:55], a[124:127], v207, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v208, v200 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[184:187], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[188:191], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v208, v200 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[192:195], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v208, v200 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v208, v200 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[196:199], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v208, v200 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[136:139], v[24:27], a[80:83], v208, v201 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v211, v227, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[136:139], v[28:31], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[56:59], v216                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[140:143], v[24:27], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[140:143], v[28:31], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[64:67], v216 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[144:147], v[32:35], a[80:83], v208, v201 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[144:147], v[36:39], a[84:87], v208, v201 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[60:63], v216 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[148:151], v[32:35], a[88:91], v208, v201 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[148:151], v[36:39], a[92:95], v208, v201 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v216 offset:576                     
+	ds_read_b32 v203, v218 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[136:139], v[40:43], a[128:131], v208, v202 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[136:139], v[44:47], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v216 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[140:143], v[40:43], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[140:143], v[44:47], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v216 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[144:147], v[48:51], a[128:131], v208, v202 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[144:147], v[52:55], a[132:135], v208, v202 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v216 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[148:151], v[48:51], a[136:139], v208, v202 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[148:151], v[52:55], a[140:143], v208, v202 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v216 offset:4800                    
+	ds_read_b32 v204, v218 offset:1280                         
+	s_cbranch_scc0 label_0914                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[152:155], v[56:59], a[0:3], v209, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v217, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[152:155], v[60:63], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v216 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[156:159], v[56:59], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v212, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[156:159], v[60:63], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v216 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[160:163], v[64:67], a[0:3], v209, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v213, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[160:163], v[68:71], a[4:7], v209, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v216 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[164:167], v[64:67], a[8:11], v209, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v219, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[164:167], v[68:71], a[12:15], v209, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v216 offset:9024                  
+	ds_read_b32 v205, v218 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[72:75], a[48:51], v209, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v220, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[76:79], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[72:75], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v219, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[76:79], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[80:83], a[48:51], v209, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v220, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[84:87], a[52:55], v209, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[80:83], a[56:59], v209, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v206, v225, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[84:87], a[60:63], v209, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[152:155], v[88:91], a[96:99], v209, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[152:155], v[92:95], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[156:159], v[88:91], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[156:159], v[92:95], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[160:163], v[96:99], a[96:99], v209, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[160:163], v[100:103], a[100:103], v209, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[164:167], v[96:99], a[104:107], v209, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[164:167], v[100:103], a[108:111], v209, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[168:171], v[56:59], a[16:19], v210, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v214, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[168:171], v[60:63], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[172:175], v[56:59], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	buffer_load_dwordx4 v[120:123], v221, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[172:175], v[60:63], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[176:179], v[64:67], a[16:19], v210, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s13, 0, s13                                     
+	buffer_load_dwordx4 v[124:127], v222, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[176:179], v[68:71], a[20:23], v210, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[180:183], v[64:67], a[24:27], v210, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s21, 0, s21                                     
+	buffer_load_dwordx4 v[128:131], v221, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[180:183], v[68:71], a[28:31], v210, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[72:75], a[64:67], v210, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v222, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[76:79], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[72:75], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v207, v226, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[76:79], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[80:83], a[64:67], v210, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[84:87], a[68:71], v210, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[80:83], a[72:75], v210, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[84:87], a[76:79], v210, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[168:171], v[88:91], a[112:115], v210, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[168:171], v[92:95], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[172:175], v[88:91], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[172:175], v[92:95], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[176:179], v[96:99], a[112:115], v210, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[176:179], v[100:103], a[116:119], v210, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[180:183], v[96:99], a[120:123], v210, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[180:183], v[100:103], a[124:127], v210, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[184:187], v[56:59], a[32:35], v211, v203 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x200, s60                                  
+	buffer_load_dwordx4 v[136:139], v223, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[184:187], v[60:63], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[188:191], v[56:59], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	buffer_load_dwordx4 v[140:143], v224, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[188:191], v[60:63], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[192:195], v[64:67], a[32:35], v211, v203 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v223, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[192:195], v[68:71], a[36:39], v211, v203 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[196:199], v[64:67], a[40:43], v211, v203 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v224, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[196:199], v[68:71], a[44:47], v211, v203 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(15)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[184:187], v[72:75], a[80:83], v211, v204 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v208, v227, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[184:187], v[76:79], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	ds_read_b128 v[8:11], v215                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[188:191], v[72:75], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s17, 0, s17                                     
+	s_sub_u32 s18, s18, s67                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[188:191], v[76:79], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s24, s24, s69                                    
+	ds_read_b128 v[16:19], v215 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[192:195], v[80:83], a[80:83], v211, v204 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[192:195], v[84:87], a[84:87], v211, v204 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	ds_read_b128 v[12:15], v215 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[196:199], v[80:83], a[88:91], v211, v204 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[196:199], v[84:87], a[92:95], v211, v204 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v215 offset:576                     
+	ds_read_b32 v200, v218                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[184:187], v[88:91], a[128:131], v211, v205 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[184:187], v[92:95], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v215 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[188:191], v[88:91], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[188:191], v[92:95], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v215 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[192:195], v[96:99], a[128:131], v211, v205 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[192:195], v[100:103], a[132:135], v211, v205 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v215 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[196:199], v[96:99], a[136:139], v211, v205 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[196:199], v[100:103], a[140:143], v211, v205 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v215 offset:4800                    
+	ds_read_b32 v201, v218 offset:256                          
+	s_cbranch_scc0 label_0914                                  
+	s_branch label_05FB                                        
+	
+label_0914:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x180                                  
+	s_mul_i32 s63, s46, 0x60                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x60                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0B64                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v232, 0, v228                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_add_u32_e32 v232, 64, v228                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_add_u32_e32 v232, 0x80, v228                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	s_branch label_0DB2                                        
+	
+label_0B64:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0DB2                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v232, 0, v228                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0DB2                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v232, 64, v228                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_0DB2                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v232, 0x80, v228                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v232, s[4:7], 0 offen       
+	v_add_u32_e32 v232, s62, v232                              
+	
+label_0DB2:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x384_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2168,7 +2168,7 @@ label_111E:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2615,14 +2615,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA.s
@@ -1,0 +1,2633 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x1ff                                  
+	s_lshr_b32 s50, s51, 9                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v181, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v181, v5, v181                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v181, v6, v181                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v181, v4, v181                               
+	v_add_u32_e32 v181, 0x800, v181                            
+	v_add_u32_e32 v182, 0x3180, v181                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v183, s63, v183                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	v_add_u32_e32 v184, 0, v184                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v185, s62, v185                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v193, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v193, s63, v193                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v194, s62, v193                              
+	v_add_u32_e32 v195, s62, v194                              
+	v_add_u32_e32 v196, s62, v195                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v176, v195, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v181                                 
+	ds_read_b128 v[16:19], v181 offset:64                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v184                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v184 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x80                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v197, s36, v5                                 
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, v4, v197                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_070A                                  
+	
+label_031B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v184 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[40:43], a[144:147], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[44:47], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[40:43], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[44:47], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[48:51], a[144:147], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[52:55], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[48:51], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[52:55], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[24:27], a[96:99], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[28:31], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[24:27], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[28:31], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[32:35], a[96:99], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[36:39], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[32:35], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[36:39], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[40:43], a[160:163], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[44:47], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[40:43], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[44:47], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[48:51], a[160:163], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[52:55], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[48:51], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[52:55], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[24:27], a[112:115], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[28:31], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[24:27], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[28:31], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[32:35], a[112:115], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[36:39], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[32:35], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[36:39], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v184 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[40:43], a[176:179], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[44:47], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[40:43], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[44:47], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[48:51], a[176:179], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[52:55], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[48:51], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[52:55], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v172, v184 offset:1280                         
+	s_cbranch_scc0 label_0AF9                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v184 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[88:91], a[128:131], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[92:95], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[88:91], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[92:95], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[96:99], a[128:131], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[100:103], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[96:99], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[100:103], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[72:75], a[80:83], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[76:79], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[72:75], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[76:79], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[80:83], a[80:83], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[84:87], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[80:83], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[84:87], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[88:91], a[144:147], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[92:95], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[88:91], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[92:95], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[96:99], a[144:147], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[100:103], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[96:99], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[100:103], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[72:75], a[96:99], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[76:79], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[72:75], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[76:79], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[80:83], a[96:99], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[84:87], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[80:83], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[84:87], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[72:75], a[112:115], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[76:79], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[72:75], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[76:79], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[80:83], a[112:115], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[84:87], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[80:83], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[84:87], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v184                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v184 offset:256                          
+	s_cbranch_scc0 label_0AF9                                  
+	s_branch label_031B                                        
+	
+label_070A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	ds_read_b32 v170, v184 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[40:43], a[144:147], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[44:47], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[40:43], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[44:47], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[48:51], a[144:147], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[52:55], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[48:51], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[52:55], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[24:27], a[96:99], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[28:31], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[24:27], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[28:31], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[32:35], a[96:99], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[36:39], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[32:35], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[36:39], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[40:43], a[160:163], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[44:47], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[40:43], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[44:47], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[48:51], a[160:163], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[52:55], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[48:51], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[52:55], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[24:27], a[112:115], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[28:31], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[24:27], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[28:31], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[32:35], a[112:115], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[36:39], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[32:35], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[36:39], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v184 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[40:43], a[176:179], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[44:47], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[40:43], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[44:47], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[48:51], a[176:179], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[52:55], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[48:51], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[52:55], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	ds_read_b32 v172, v184 offset:1280                         
+	s_cbranch_scc0 label_0AF9                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	ds_read_b32 v173, v184 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[88:91], a[128:131], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[92:95], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[88:91], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[92:95], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[96:99], a[128:131], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[100:103], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[96:99], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[100:103], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[72:75], a[80:83], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[76:79], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[72:75], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[76:79], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[80:83], a[80:83], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[84:87], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[80:83], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[84:87], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[88:91], a[144:147], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[92:95], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[88:91], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[92:95], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[96:99], a[144:147], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[100:103], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[96:99], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[100:103], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[72:75], a[96:99], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[76:79], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[72:75], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[76:79], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[80:83], a[96:99], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[84:87], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[80:83], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[84:87], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[72:75], a[112:115], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[76:79], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[72:75], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[76:79], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[80:83], a[112:115], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[84:87], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[80:83], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[84:87], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v184                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v184 offset:256                          
+	s_cbranch_scc0 label_0AF9                                  
+	s_branch label_070A                                        
+	
+label_0AF9:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_i32 s63, s46, 0x80                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x80                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0E0B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v201, 0, v197                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_add_u32_e32 v201, 64, v197                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_add_u32_e32 v201, 0x80, v197                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_add_u32_e32 v201, 0xc0, v197                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_branch label_111E                                        
+	
+label_0E0B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 0, v197                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 64, v197                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 0x80, v197                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 0xc0, v197                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	
+label_111E:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB.s
@@ -1,0 +1,2633 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x1ff                                  
+	s_lshr_b32 s50, s51, 9                                     
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0059:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_005E                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0059                                        
+	
+label_005E:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0064                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_0084                                        
+	
+label_0064:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_0084:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v178, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v178, v4, v178                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v178, s62, v178                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v179, s62, v178                              
+	v_add_u32_e32 v180, s62, v179                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v181, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v181, v5, v181                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v181, v6, v181                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v181, v4, v181                               
+	v_add_u32_e32 v181, 0x800, v181                            
+	v_add_u32_e32 v182, 0x3180, v181                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v183, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v183, s63, v183                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v184, 2, v0                              
+	v_add_u32_e32 v184, 0, v184                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v185, 4, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v185, s62, v185                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v186, s62, v185                              
+	v_add_u32_e32 v187, s62, v186                              
+	v_add_u32_e32 v188, s62, v187                              
+	v_add_u32_e32 v189, s62, v188                              
+	v_add_u32_e32 v190, s62, v189                              
+	v_add_u32_e32 v191, s62, v190                              
+	v_add_u32_e32 v192, s62, v191                              
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x200                                    
+	s_cselect_b32 s62, s63, 0x200                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v193, 2, v0                              
+	s_mul_i32 s63, s46, 0x80                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v193, s63, v193                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v194, s62, v193                              
+	v_add_u32_e32 v195, s62, v194                              
+	v_add_u32_e32 v196, s62, v195                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v176, v195, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v181                                 
+	ds_read_b128 v[16:19], v181 offset:64                      
+	ds_read_b128 v[12:15], v181 offset:512                     
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v184                                     
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v184 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x200                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0x80                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v197, s36, v5                                 
+	v_add_u32_e32 v197, s62, v197                              
+	v_add_u32_e32 v197, v4, v197                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_070A                                  
+	
+label_031B:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v170, v184 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[40:43], a[144:147], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[44:47], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[40:43], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[44:47], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[48:51], a[144:147], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[52:55], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[48:51], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[52:55], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[24:27], a[96:99], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[28:31], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[24:27], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[28:31], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[32:35], a[96:99], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[36:39], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[32:35], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[36:39], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[40:43], a[160:163], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[44:47], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[40:43], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[44:47], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[48:51], a[160:163], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[52:55], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[48:51], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[52:55], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[24:27], a[112:115], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[28:31], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[24:27], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[28:31], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[32:35], a[112:115], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[36:39], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[32:35], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[36:39], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v171, v184 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[40:43], a[176:179], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[44:47], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[40:43], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[44:47], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[48:51], a[176:179], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[52:55], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[48:51], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[52:55], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v172, v184 offset:1280                         
+	s_cbranch_scc0 label_0AF9                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v173, v184 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[88:91], a[128:131], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[92:95], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[88:91], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[92:95], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[96:99], a[128:131], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[100:103], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[96:99], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[100:103], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[72:75], a[80:83], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[76:79], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[72:75], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[76:79], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[80:83], a[80:83], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[84:87], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[80:83], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[84:87], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[88:91], a[144:147], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[92:95], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[88:91], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[92:95], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[96:99], a[144:147], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[100:103], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[96:99], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[100:103], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[72:75], a[96:99], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[76:79], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[72:75], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[76:79], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[80:83], a[96:99], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[84:87], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[80:83], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[84:87], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[72:75], a[112:115], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[76:79], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[72:75], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[76:79], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[80:83], a[112:115], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[84:87], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[80:83], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[84:87], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v168, v184                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v169, v184 offset:256                          
+	s_cbranch_scc0 label_0AF9                                  
+	s_branch label_031B                                        
+	
+label_070A:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v174, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[40:43], v181 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v181 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v174, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v174, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v181 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v174, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v174, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v181 offset:9024                    
+	ds_read_b32 v170, v184 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[24:27], a[64:67], v174, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[28:31], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[24:27], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[28:31], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[32:35], a[64:67], v174, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[36:39], a[68:71], v174, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[32:35], a[72:75], v174, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[36:39], a[76:79], v174, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[40:43], a[128:131], v174, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[44:47], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[40:43], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[44:47], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[48:51], a[128:131], v174, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[52:55], a[132:135], v174, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[48:51], a[136:139], v174, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[52:55], a[140:143], v174, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v175, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v175, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v175, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v175, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v175, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[24:27], a[80:83], v175, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[28:31], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[24:27], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[28:31], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[32:35], a[80:83], v175, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[36:39], a[84:87], v175, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[32:35], a[88:91], v175, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[36:39], a[92:95], v175, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[40:43], a[144:147], v175, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[44:47], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[40:43], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[44:47], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[48:51], a[144:147], v175, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[52:55], a[148:151], v175, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[48:51], a[152:155], v175, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[52:55], a[156:159], v175, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v176, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v176, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v176, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v176, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v176, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[24:27], a[96:99], v176, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[28:31], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[24:27], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[28:31], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[32:35], a[96:99], v176, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[36:39], a[100:103], v176, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[32:35], a[104:107], v176, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[36:39], a[108:111], v176, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[40:43], a[160:163], v176, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[44:47], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[40:43], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[44:47], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[48:51], a[160:163], v176, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[52:55], a[164:167], v176, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[48:51], a[168:171], v176, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[52:55], a[172:175], v176, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v177, v168 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v177, v168 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v177, v168 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v177, v168 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v177, v168 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[24:27], a[112:115], v177, v169 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[28:31], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v182                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[24:27], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[28:31], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v182 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[32:35], a[112:115], v177, v169 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[36:39], a[116:119], v177, v169 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v182 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[32:35], a[120:123], v177, v169 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[36:39], a[124:127], v177, v169 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v182 offset:576                     
+	ds_read_b32 v171, v184 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[40:43], a[176:179], v177, v170 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[44:47], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v182 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[40:43], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[44:47], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v182 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[48:51], a[176:179], v177, v170 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[52:55], a[180:183], v177, v170 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v182 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[48:51], a[184:187], v177, v170 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[52:55], a[188:191], v177, v170 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v182 offset:4800                    
+	ds_read_b32 v172, v184 offset:1280                         
+	s_cbranch_scc0 label_0AF9                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v174, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[152:155], v191, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	ds_read_b128 v[88:91], v182 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v182 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v174, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v192, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v174, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v182 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v174, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v174, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v182 offset:9024                  
+	ds_read_b32 v173, v184 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[104:107], v[72:75], a[64:67], v174, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v191, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[104:107], v[76:79], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[108:111], v[72:75], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[108:111], v[76:79], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[112:115], v[80:83], a[64:67], v174, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v192, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[112:115], v[84:87], a[68:71], v174, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[116:119], v[80:83], a[72:75], v174, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[116:119], v[84:87], a[76:79], v174, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[104:107], v[88:91], a[128:131], v174, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v177, v196, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[104:107], v[92:95], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[108:111], v[88:91], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[108:111], v[92:95], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[112:115], v[96:99], a[128:131], v174, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v183, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[112:115], v[100:103], a[132:135], v174, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[116:119], v[96:99], a[136:139], v174, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[116:119], v[100:103], a[140:143], v174, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v175, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v178, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v179, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v175, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v185, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v175, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v175, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v175, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[120:123], v[72:75], a[80:83], v175, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v186, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[120:123], v[76:79], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[124:127], v[72:75], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[124:127], v[76:79], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[128:131], v[80:83], a[80:83], v175, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v185, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[128:131], v[84:87], a[84:87], v175, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[132:135], v[80:83], a[88:91], v175, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[132:135], v[84:87], a[92:95], v175, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[120:123], v[88:91], a[144:147], v175, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v186, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[120:123], v[92:95], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[124:127], v[88:91], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[124:127], v[92:95], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[128:131], v[96:99], a[144:147], v175, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v174, v193, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[128:131], v[100:103], a[148:151], v175, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[132:135], v[96:99], a[152:155], v175, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[132:135], v[100:103], a[156:159], v175, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v176, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v180, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v176, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v187, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v176, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v176, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v176, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[136:139], v[72:75], a[96:99], v176, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v188, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[136:139], v[76:79], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[140:143], v[72:75], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[140:143], v[76:79], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[144:147], v[80:83], a[96:99], v176, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v187, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[144:147], v[84:87], a[100:103], v176, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[148:151], v[80:83], a[104:107], v176, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[148:151], v[84:87], a[108:111], v176, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[136:139], v[88:91], a[160:163], v176, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v188, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[136:139], v[92:95], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[140:143], v[88:91], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[140:143], v[92:95], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[144:147], v[96:99], a[160:163], v176, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v175, v194, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[144:147], v[100:103], a[164:167], v176, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[148:151], v[96:99], a[168:171], v176, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[148:151], v[100:103], a[172:175], v176, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v177, v171 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v189, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v177, v171 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v190, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v177, v171 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v177, v171 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v177, v171 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[152:155], v[72:75], a[112:115], v177, v172 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v189, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[152:155], v[76:79], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v181                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[156:159], v[72:75], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[156:159], v[76:79], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v181 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[160:163], v[80:83], a[112:115], v177, v172 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v190, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[160:163], v[84:87], a[116:119], v177, v172 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v181 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[164:167], v[80:83], a[120:123], v177, v172 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[164:167], v[84:87], a[124:127], v177, v172 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v181 offset:576                     
+	ds_read_b32 v168, v184                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[152:155], v[88:91], a[176:179], v177, v173 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v176, v195, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[152:155], v[92:95], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v181 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[156:159], v[88:91], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[156:159], v[92:95], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v181 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[160:163], v[96:99], a[176:179], v177, v173 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[160:163], v[100:103], a[180:183], v177, v173 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v181 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[164:167], v[96:99], a[184:187], v177, v173 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[164:167], v[100:103], a[188:191], v177, v173 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v181 offset:4800                    
+	ds_read_b32 v169, v184 offset:256                          
+	s_cbranch_scc0 label_0AF9                                  
+	s_branch label_070A                                        
+	
+label_0AF9:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x200                                  
+	s_mul_i32 s63, s46, 0x80                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0x80                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_0E0B                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v201, 0, v197                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_add_u32_e32 v201, 64, v197                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_add_u32_e32 v201, 0x80, v197                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_add_u32_e32 v201, 0xc0, v197                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_branch label_111E                                        
+	
+label_0E0B:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 0, v197                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 64, v197                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 0x80, v197                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_111E                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v201, 0xc0, v197                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v201, s[4:7], 0 offen       
+	v_add_u32_e32 v201, s62, v201                              
+	
+label_111E:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x512_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640
 .p2align 8
-.type _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E,@function
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640,@function
 
-_ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E:
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
@@ -2597,7 +2597,7 @@ label_14D3:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -3044,14 +3044,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 384
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter41f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA.s
@@ -1,0 +1,3062 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x27f                                  
+	s_mov_b32 s63, 0x280                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0078:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_007D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0078                                        
+	
+label_007D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0083                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_00A3                                        
+	
+label_0083:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_00A3:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v198, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v198, v5, v198                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v198, v6, v198                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v198, v4, v198                               
+	v_add_u32_e32 v198, 0x800, v198                            
+	v_add_u32_e32 v199, 0x3180, v198                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v200, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v200, s63, v200                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v201, 2, v0                              
+	v_add_u32_e32 v201, 0, v201                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v202, 4, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v202, s62, v202                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v212, 2, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v212, s63, v212                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v192, v214, s[24:27], 0 offen            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v198                                 
+	ds_read_b128 v[16:19], v198 offset:64                      
+	ds_read_b128 v[12:15], v198 offset:512                     
+	ds_read_b128 v[20:23], v198 offset:576                     
+	ds_read_b32 v184, v201                                     
+	ds_read_b128 v[24:27], v198 offset:4224                    
+	ds_read_b128 v[32:35], v198 offset:4288                    
+	ds_read_b128 v[28:31], v198 offset:4736                    
+	ds_read_b128 v[36:39], v198 offset:4800                    
+	ds_read_b32 v185, v201 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x280                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xa0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v217, s36, v5                                 
+	v_add_u32_e32 v217, s62, v217                              
+	v_add_u32_e32 v217, v4, v217                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0862                                  
+	
+label_039D:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v198 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v201 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[40:43], a[160:163], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[44:47], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[40:43], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[44:47], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[48:51], a[160:163], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[52:55], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[48:51], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[52:55], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[24:27], a[96:99], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[28:31], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[24:27], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[28:31], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[32:35], a[96:99], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[36:39], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[32:35], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[36:39], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[40:43], a[176:179], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[44:47], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[40:43], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[44:47], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[48:51], a[176:179], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[52:55], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[48:51], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[52:55], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[24:27], a[112:115], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[28:31], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[24:27], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[28:31], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[32:35], a[112:115], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[36:39], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[40:43], a[192:195], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[44:47], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[40:43], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[44:47], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[48:51], a[192:195], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[52:55], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[48:51], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[52:55], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[24:27], a[128:131], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[28:31], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[24:27], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[28:31], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[32:35], a[128:131], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[36:39], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[32:35], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[36:39], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[40:43], a[208:211], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[44:47], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[40:43], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[44:47], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[48:51], a[208:211], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[52:55], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[48:51], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[52:55], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[8:11], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[12:15], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[16:19], a[64:67], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[20:23], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[16:19], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[20:23], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[24:27], a[144:147], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[28:31], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[24:27], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[28:31], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[32:35], a[144:147], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[36:39], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[32:35], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[36:39], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v201 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[40:43], a[224:227], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v199 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[44:47], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[40:43], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v199 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[44:47], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[48:51], a[224:227], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v199 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[52:55], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[48:51], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v199 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[52:55], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v201 offset:1280                         
+	s_cbranch_scc0 label_0D27                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v199 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v199 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v199 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v199 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v201 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[72:75], a[80:83], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[76:79], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[72:75], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[76:79], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[80:83], a[80:83], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[84:87], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[80:83], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[84:87], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v190, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v190, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[72:75], a[96:99], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[76:79], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[72:75], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[76:79], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[80:83], a[96:99], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[84:87], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[80:83], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[84:87], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[72:75], a[112:115], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[76:79], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[72:75], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[76:79], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[80:83], a[112:115], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[84:87], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[80:83], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[84:87], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[88:91], a[192:195], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[92:95], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[88:91], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[92:95], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[96:99], a[192:195], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[100:103], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[96:99], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[100:103], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[88:91], a[208:211], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[92:95], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[88:91], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[92:95], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[96:99], a[208:211], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[100:103], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[96:99], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[100:103], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[56:59], a[64:67], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[60:63], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[56:59], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[60:63], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[64:67], a[64:67], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[68:71], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[64:67], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[68:71], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v198                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v198 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v201                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[88:91], a[224:227], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[92:95], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[88:91], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[92:95], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[96:99], a[224:227], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[100:103], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[96:99], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v198 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[100:103], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v201 offset:256                          
+	s_cbranch_scc0 label_0D27                                  
+	s_branch label_039D                                        
+	
+label_0862:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v198 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:9024                    
+	ds_read_b32 v186, v201 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[40:43], a[160:163], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[44:47], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[40:43], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[44:47], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[48:51], a[160:163], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[52:55], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[48:51], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[52:55], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[24:27], a[96:99], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[28:31], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[24:27], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[28:31], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[32:35], a[96:99], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[36:39], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[32:35], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[36:39], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[40:43], a[176:179], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[44:47], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[40:43], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[44:47], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[48:51], a[176:179], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[52:55], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[48:51], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[52:55], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[24:27], a[112:115], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[28:31], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[24:27], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[28:31], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[32:35], a[112:115], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[36:39], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[40:43], a[192:195], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[44:47], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[40:43], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[44:47], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[48:51], a[192:195], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[52:55], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[48:51], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[52:55], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[24:27], a[128:131], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[28:31], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[24:27], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[28:31], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[32:35], a[128:131], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[36:39], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[32:35], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[36:39], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[40:43], a[208:211], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[44:47], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[40:43], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[44:47], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[48:51], a[208:211], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[52:55], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[48:51], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[52:55], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[8:11], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[12:15], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[16:19], a[64:67], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[20:23], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[16:19], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[20:23], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[24:27], a[144:147], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[28:31], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[24:27], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[28:31], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[32:35], a[144:147], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[36:39], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[32:35], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[36:39], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	ds_read_b32 v187, v201 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[40:43], a[224:227], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[44:47], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v199 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[40:43], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[44:47], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v199 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[48:51], a[224:227], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[52:55], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v199 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[48:51], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[52:55], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v199 offset:4800                    
+	ds_read_b32 v188, v201 offset:1280                         
+	s_cbranch_scc0 label_0D27                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v199 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v199 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v199 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v199 offset:9024                  
+	ds_read_b32 v189, v201 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[72:75], a[80:83], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[76:79], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[72:75], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[76:79], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[80:83], a[80:83], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[84:87], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[80:83], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[84:87], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v190, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v190, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[72:75], a[96:99], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[76:79], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[72:75], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[76:79], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[80:83], a[96:99], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[84:87], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[80:83], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[84:87], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[72:75], a[112:115], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[76:79], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[72:75], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[76:79], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[80:83], a[112:115], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[84:87], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[80:83], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[84:87], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[88:91], a[192:195], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[92:95], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[88:91], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[92:95], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[96:99], a[192:195], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[100:103], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[96:99], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[100:103], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen nt lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[88:91], a[208:211], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[92:95], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[88:91], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[92:95], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[96:99], a[208:211], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[100:103], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[96:99], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[100:103], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[56:59], a[64:67], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[60:63], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[56:59], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[60:63], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[64:67], a[64:67], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[68:71], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[64:67], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[68:71], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v198                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v198 offset:576                     
+	ds_read_b32 v184, v201                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[88:91], a[224:227], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[92:95], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[88:91], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[92:95], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[96:99], a[224:227], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[100:103], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[96:99], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[100:103], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v198 offset:4800                    
+	ds_read_b32 v185, v201 offset:256                          
+	s_cbranch_scc0 label_0D27                                  
+	s_branch label_0862                                        
+	
+label_0D27:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xa0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_10FB                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v221, 0, v217                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 64, v217                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 0x80, v217                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 0xc0, v217                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 0x100, v217                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_branch label_14D3                                        
+	
+label_10FB:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0, v217                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 64, v217                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0x80, v217                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0xc0, v217                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0x100, v217                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	
+label_14D3:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntA.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB.s
@@ -1,0 +1,3062 @@
+// Auto-generated from f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB.co
+// This file can be reassembled with:
+//   clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950 -c file.s -o file.o
+//   ld.lld -shared -o file.co file.o
+
+// Note: Target is specified via -mcpu= command line flag
+
+.set .amdgcn.next_free_vgpr, 0
+.set .amdgcn.next_free_sgpr, 0
+
+// ===== Kernel Code =====
+.text
+.globl f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB
+.p2align 8
+.type f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB,@function
+
+f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB:
+	
+	s_and_b32 s1, s1, 0xffff                                   
+	s_load_dwordx2 s[4:5], s[0:1], 0x0                         
+	s_load_dwordx2 s[8:9], s[0:1], 0x10                        
+	s_load_dwordx2 s[12:13], s[0:1], 0x20                      
+	s_load_dwordx2 s[16:17], s[0:1], 0x30                      
+	s_load_dword s41, s[0:1], 0x40                             
+	s_load_dword s42, s[0:1], 0x50                             
+	s_load_dword s36, s[0:1], 0x80                             
+	s_load_dword s37, s[0:1], 0xa0                             
+	s_load_dword s38, s[0:1], 0xc0                             
+	s_load_dword s43, s[0:1], 0xe0                             
+	s_load_dword s44, s[0:1], 0xf0                             
+	s_load_dword s45, s[0:1], 0x100                            
+	s_load_dwordx2 s[20:21], s[0:1], 0x110                     
+	s_load_dwordx2 s[24:25], s[0:1], 0x120                     
+	s_load_dword s39, s[0:1], 0x130                            
+	s_load_dword s40, s[0:1], 0x150                            
+	v_lshrrev_b32_e32 v1, 10, v0                               
+	v_lshrrev_b32_e32 v2, 10, v1                               
+	v_and_b32_e32 v2, 0x3ff, v2                                
+	v_and_b32_e32 v1, 0x3ff, v1                                
+	v_and_b32_e32 v0, 0x3ff, v0                                
+	v_lshrrev_b32_e32 v3, 6, v0                                
+	v_and_b32_e32 v0, 63, v0                                   
+	s_mov_b32 s47, s2                                          
+	s_mov_b32 s48, s3                                          
+	v_readfirstlane_b32 s46, v3                                
+	s_waitcnt lgkmcnt(0)                                       
+	s_add_u32 s51, s44, 0x27f                                  
+	s_mov_b32 s63, 0x280                                       
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s50, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s50, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s50, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s49, s50, s48                                    
+	s_add_i32 s49, s49, s47                                    
+	s_add_u32 s51, s43, 0x5f                                   
+	s_mov_b32 s63, 0x60                                        
+	v_cvt_f32_u32_e32 v4, s63                                  
+	s_sub_i32 s62, 0, s63                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s62, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s51, v4                                   
+	v_mul_lo_u32 v5, v4, s63                                   
+	v_sub_u32_e32 v7, s51, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	v_subrev_u32_e32 v5, s63, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s63, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s62, v7                                
+	s_nop 3                                                    
+	s_lshl_b32 s62, s62, 5                                     
+	s_mov_b32 s47, 0                                           
+	
+label_0078:
+	s_cmp_lt_i32 s49, s62                                      
+	s_cbranch_scc1 label_007D                                  
+	s_sub_i32 s49, s49, s62                                    
+	s_add_i32 s47, s47, 32                                     
+	s_branch label_0078                                        
+	
+label_007D:
+	s_sub_i32 s50, s50, s47                                    
+	s_cmp_lt_i32 s50, 32                                       
+	s_cbranch_scc1 label_0083                                  
+	s_lshr_b32 s48, s49, 5                                     
+	s_and_b32 s62, s49, 31                                     
+	s_branch label_00A3                                        
+	
+label_0083:
+	v_cvt_f32_u32_e32 v4, s50                                  
+	s_sub_i32 s48, 0, s50                                      
+	v_rcp_iflag_f32_e32 v4, v4                                 
+	s_nop 0                                                    
+	v_mul_f32_e32 v4, 0x4f7ffffe, v4                           
+	v_cvt_u32_f32_e32 v4, v4                                   
+	v_mul_lo_u32 v5, s48, v4                                   
+	v_mul_hi_u32 v5, v4, v5                                    
+	v_add_u32_e32 v4, v4, v5                                   
+	v_mul_hi_u32 v4, s49, v4                                   
+	v_mul_lo_u32 v5, v4, s50                                   
+	v_sub_u32_e32 v7, s49, v5                                  
+	v_add_u32_e32 v6, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	v_subrev_u32_e32 v5, s50, v7                               
+	s_nop 0                                                    
+	v_cndmask_b32_e32 v4, v4, v6, vcc                          
+	v_cndmask_b32_e32 v7, v7, v5, vcc                          
+	v_add_u32_e32 v5, 1, v4                                    
+	v_cmp_le_u32_e32 vcc, s50, v7                              
+	s_nop 1                                                    
+	v_cndmask_b32_e32 v7, v4, v5, vcc                          
+	s_nop 3                                                    
+	v_readfirstlane_b32 s48, v7                                
+	s_nop 3                                                    
+	s_mul_i32 s62, s50, s48                                    
+	s_sub_i32 s62, s49, s62                                    
+	
+label_00A3:
+	s_add_i32 s47, s62, s47                                    
+	s_lshr_b32 s37, s37, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s37, s62                                 
+	s_add_u32 s13, s13, s63                                    
+	s_mul_i32 s63, s37, s62                                    
+	s_add_u32 s12, s12, s63                                    
+	s_addc_u32 s13, s13, 0                                     
+	s_sub_i32 s63, s43, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s14, s37, s62                                    
+	s_mov_b32 s15, 0x20000                                     
+	v_lshrrev_b32_e32 v4, 3, v0                                
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_lshlrev_b32_e32 v5, 4, v5                                
+	v_and_b32_e32 v4, 3, v4                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_lshlrev_b32_e32 v6, 2, v6                                
+	v_add_u32_e32 v5, v5, v6                                   
+	v_and_b32_e32 v4, 1, v4                                    
+	v_add_u32_e32 v5, v5, v4                                   
+	v_mul_lo_u32 v195, s37, v5                                 
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshlrev_b32_e32 v4, 4, v4                                
+	v_add_u32_e32 v195, v4, v195                               
+	s_lshr_b32 s62, s46, 1                                     
+	s_mul_i32 s62, s62, 8                                      
+	s_and_b32 s63, s46, 1                                      
+	s_mul_i32 s63, s63, 2                                      
+	s_add_u32 s62, s62, s63                                    
+	s_mul_i32 s62, s37, s62                                    
+	v_add_u32_e32 v195, s62, v195                              
+	s_mul_i32 s62, s37, 32                                     
+	v_add_u32_e32 v196, s62, v195                              
+	v_add_u32_e32 v197, s62, v196                              
+	s_mul_i32 s64, 0x420, s46                                  
+	s_add_u32 s64, 0x800, s64                                  
+	v_and_b32_e32 v4, 15, v0                                   
+	v_lshrrev_b32_e32 v5, 3, v4                                
+	v_mul_i32_i24_e32 v5, 2, v5                                
+	v_and_b32_e32 v4, 3, v0                                    
+	v_lshrrev_b32_e32 v6, 1, v4                                
+	v_add_u32_e32 v4, v5, v6                                   
+	v_mul_i32_i24_e32 v198, 0x420, v4                          
+	v_and_b32_e32 v4, 7, v0                                    
+	v_lshrrev_b32_e32 v5, 2, v4                                
+	v_mul_i32_i24_e32 v5, 0x100, v5                            
+	v_add_u32_e32 v198, v5, v198                               
+	v_and_b32_e32 v4, 1, v0                                    
+	v_mul_i32_i24_e32 v6, 0x80, v4                             
+	v_add_u32_e32 v198, v6, v198                               
+	v_lshrrev_b32_e32 v4, 4, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_add_u32_e32 v198, v4, v198                               
+	v_add_u32_e32 v198, 0x800, v198                            
+	v_add_u32_e32 v199, 0x3180, v198                           
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s39, s62                                 
+	s_add_u32 s21, s21, s63                                    
+	s_mul_i32 s63, s39, s62                                    
+	s_add_u32 s20, s20, s63                                    
+	s_addc_u32 s21, s21, 0                                     
+	s_add_u32 s63, s43, 31                                     
+	s_lshr_b32 s63, s63, 5                                     
+	s_lshl_b32 s63, s63, 5                                     
+	s_sub_i32 s63, s63, s62                                    
+	s_cmp_lt_u32 s63, 0x60                                     
+	s_cselect_b32 s62, s63, 0x60                               
+	s_mul_i32 s22, s39, s62                                    
+	s_mov_b32 s23, 0x20000                                     
+	v_lshlrev_b32_e32 v200, 2, v0                              
+	s_mul_i32 s63, s46, 32                                     
+	s_mul_i32 s63, s63, s39                                    
+	v_add_u32_e32 v200, s63, v200                              
+	s_mul_i32 s65, s46, 0x100                                  
+	s_add_i32 s65, s65, 0                                      
+	v_lshlrev_b32_e32 v201, 2, v0                              
+	v_add_u32_e32 v201, 0, v201                                
+	s_lshr_b32 s38, s38, 1                                     
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s38, s62                                 
+	s_add_u32 s17, s17, s63                                    
+	s_mul_i32 s63, s38, s62                                    
+	s_add_u32 s16, s16, s63                                    
+	s_addc_u32 s17, s17, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s18, s38, s62                                    
+	s_mov_b32 s19, 0x20000                                     
+	v_lshlrev_b32_e32 v202, 4, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s62, s63, s38                                    
+	v_add_u32_e32 v202, s62, v202                              
+	s_mul_i32 s62, 16, s38                                     
+	v_add_u32_e32 v203, s62, v202                              
+	v_add_u32_e32 v204, s62, v203                              
+	v_add_u32_e32 v205, s62, v204                              
+	v_add_u32_e32 v206, s62, v205                              
+	v_add_u32_e32 v207, s62, v206                              
+	v_add_u32_e32 v208, s62, v207                              
+	v_add_u32_e32 v209, s62, v208                              
+	v_add_u32_e32 v210, s62, v209                              
+	v_add_u32_e32 v211, s62, v210                              
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_hi_u32 s63, s40, s62                                 
+	s_add_u32 s25, s25, s63                                    
+	s_mul_i32 s63, s40, s62                                    
+	s_add_u32 s24, s24, s63                                    
+	s_addc_u32 s25, s25, 0                                     
+	s_sub_i32 s63, s44, s62                                    
+	s_cmp_lt_u32 s63, 0x280                                    
+	s_cselect_b32 s62, s63, 0x280                              
+	s_mul_i32 s26, s40, s62                                    
+	s_mov_b32 s27, 0x20000                                     
+	v_lshlrev_b32_e32 v212, 2, v0                              
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_mul_i32 s63, s63, s40                                    
+	v_add_u32_e32 v212, s63, v212                              
+	s_mul_i32 s62, 32, s40                                     
+	v_add_u32_e32 v213, s62, v212                              
+	v_add_u32_e32 v214, s62, v213                              
+	v_add_u32_e32 v215, s62, v214                              
+	v_add_u32_e32 v216, s62, v215                              
+	s_mov_b32 s66, 0x80                                        
+	s_mov_b32 s67, 0x800                                       
+	s_mov_b32 s68, 0x100                                       
+	s_mov_b32 s69, 0x100                                       
+	s_mov_b32 s60, 0                                           
+	s_mov_b32 s61, s45                                         
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_accvgpr_write_b32 a0, 0                                  
+	v_accvgpr_write_b32 a1, 0                                  
+	v_accvgpr_write_b32 a2, 0                                  
+	v_accvgpr_write_b32 a3, 0                                  
+	v_accvgpr_write_b32 a4, 0                                  
+	v_accvgpr_write_b32 a5, 0                                  
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a6, 0                                  
+	v_accvgpr_write_b32 a7, 0                                  
+	v_accvgpr_write_b32 a8, 0                                  
+	v_accvgpr_write_b32 a9, 0                                  
+	v_accvgpr_write_b32 a10, 0                                 
+	v_accvgpr_write_b32 a11, 0                                 
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a12, 0                                 
+	v_accvgpr_write_b32 a13, 0                                 
+	v_accvgpr_write_b32 a14, 0                                 
+	v_accvgpr_write_b32 a15, 0                                 
+	v_accvgpr_write_b32 a16, 0                                 
+	v_accvgpr_write_b32 a17, 0                                 
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a18, 0                                 
+	v_accvgpr_write_b32 a19, 0                                 
+	v_accvgpr_write_b32 a20, 0                                 
+	v_accvgpr_write_b32 a21, 0                                 
+	v_accvgpr_write_b32 a22, 0                                 
+	v_accvgpr_write_b32 a23, 0                                 
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a24, 0                                 
+	v_accvgpr_write_b32 a25, 0                                 
+	v_accvgpr_write_b32 a26, 0                                 
+	v_accvgpr_write_b32 a27, 0                                 
+	v_accvgpr_write_b32 a28, 0                                 
+	v_accvgpr_write_b32 a29, 0                                 
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a30, 0                                 
+	v_accvgpr_write_b32 a31, 0                                 
+	v_accvgpr_write_b32 a32, 0                                 
+	v_accvgpr_write_b32 a33, 0                                 
+	v_accvgpr_write_b32 a34, 0                                 
+	v_accvgpr_write_b32 a35, 0                                 
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a36, 0                                 
+	v_accvgpr_write_b32 a37, 0                                 
+	v_accvgpr_write_b32 a38, 0                                 
+	v_accvgpr_write_b32 a39, 0                                 
+	v_accvgpr_write_b32 a40, 0                                 
+	v_accvgpr_write_b32 a41, 0                                 
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a42, 0                                 
+	v_accvgpr_write_b32 a43, 0                                 
+	v_accvgpr_write_b32 a44, 0                                 
+	v_accvgpr_write_b32 a45, 0                                 
+	v_accvgpr_write_b32 a46, 0                                 
+	v_accvgpr_write_b32 a47, 0                                 
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_accvgpr_write_b32 a48, 0                                 
+	v_accvgpr_write_b32 a49, 0                                 
+	v_accvgpr_write_b32 a50, 0                                 
+	v_accvgpr_write_b32 a51, 0                                 
+	v_accvgpr_write_b32 a52, 0                                 
+	v_accvgpr_write_b32 a53, 0                                 
+	s_add_u32 s62, 0x100, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	s_sub_u32 s14, s14, s66                                    
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	s_sub_u32 s22, s22, s68                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a54, 0                                 
+	v_accvgpr_write_b32 a55, 0                                 
+	v_accvgpr_write_b32 a56, 0                                 
+	v_accvgpr_write_b32 a57, 0                                 
+	v_accvgpr_write_b32 a58, 0                                 
+	v_accvgpr_write_b32 a59, 0                                 
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a60, 0                                 
+	v_accvgpr_write_b32 a61, 0                                 
+	v_accvgpr_write_b32 a62, 0                                 
+	v_accvgpr_write_b32 a63, 0                                 
+	v_accvgpr_write_b32 a64, 0                                 
+	v_accvgpr_write_b32 a65, 0                                 
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a66, 0                                 
+	v_accvgpr_write_b32 a67, 0                                 
+	v_accvgpr_write_b32 a68, 0                                 
+	v_accvgpr_write_b32 a69, 0                                 
+	v_accvgpr_write_b32 a70, 0                                 
+	v_accvgpr_write_b32 a71, 0                                 
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a72, 0                                 
+	v_accvgpr_write_b32 a73, 0                                 
+	v_accvgpr_write_b32 a74, 0                                 
+	v_accvgpr_write_b32 a75, 0                                 
+	v_accvgpr_write_b32 a76, 0                                 
+	v_accvgpr_write_b32 a77, 0                                 
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a78, 0                                 
+	v_accvgpr_write_b32 a79, 0                                 
+	v_accvgpr_write_b32 a80, 0                                 
+	v_accvgpr_write_b32 a81, 0                                 
+	v_accvgpr_write_b32 a82, 0                                 
+	v_accvgpr_write_b32 a83, 0                                 
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a84, 0                                 
+	v_accvgpr_write_b32 a85, 0                                 
+	v_accvgpr_write_b32 a86, 0                                 
+	v_accvgpr_write_b32 a87, 0                                 
+	v_accvgpr_write_b32 a88, 0                                 
+	v_accvgpr_write_b32 a89, 0                                 
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen nt    
+	v_accvgpr_write_b32 a90, 0                                 
+	v_accvgpr_write_b32 a91, 0                                 
+	v_accvgpr_write_b32 a92, 0                                 
+	v_accvgpr_write_b32 a93, 0                                 
+	v_accvgpr_write_b32 a94, 0                                 
+	v_accvgpr_write_b32 a95, 0                                 
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a96, 0                                 
+	v_accvgpr_write_b32 a97, 0                                 
+	v_accvgpr_write_b32 a98, 0                                 
+	v_accvgpr_write_b32 a99, 0                                 
+	v_accvgpr_write_b32 a100, 0                                
+	v_accvgpr_write_b32 a101, 0                                
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_accvgpr_write_b32 a102, 0                                
+	v_accvgpr_write_b32 a103, 0                                
+	v_accvgpr_write_b32 a104, 0                                
+	v_accvgpr_write_b32 a105, 0                                
+	v_accvgpr_write_b32 a106, 0                                
+	v_accvgpr_write_b32 a107, 0                                
+	buffer_load_dword v192, v214, s[24:27], 0 offen nt            
+	v_accvgpr_write_b32 a108, 0                                
+	v_accvgpr_write_b32 a109, 0                                
+	v_accvgpr_write_b32 a110, 0                                
+	v_accvgpr_write_b32 a111, 0                                
+	v_accvgpr_write_b32 a112, 0                                
+	v_accvgpr_write_b32 a113, 0                                
+	v_accvgpr_write_b32 a114, 0                                
+	v_accvgpr_write_b32 a115, 0                                
+	v_accvgpr_write_b32 a116, 0                                
+	v_accvgpr_write_b32 a117, 0                                
+	v_accvgpr_write_b32 a118, 0                                
+	v_accvgpr_write_b32 a119, 0                                
+	v_accvgpr_write_b32 a120, 0                                
+	v_accvgpr_write_b32 a121, 0                                
+	v_accvgpr_write_b32 a122, 0                                
+	v_accvgpr_write_b32 a123, 0                                
+	v_accvgpr_write_b32 a124, 0                                
+	v_accvgpr_write_b32 a125, 0                                
+	v_accvgpr_write_b32 a126, 0                                
+	v_accvgpr_write_b32 a127, 0                                
+	v_accvgpr_write_b32 a128, 0                                
+	v_accvgpr_write_b32 a129, 0                                
+	v_accvgpr_write_b32 a130, 0                                
+	v_accvgpr_write_b32 a131, 0                                
+	v_accvgpr_write_b32 a132, 0                                
+	v_accvgpr_write_b32 a133, 0                                
+	v_accvgpr_write_b32 a134, 0                                
+	v_accvgpr_write_b32 a135, 0                                
+	v_accvgpr_write_b32 a136, 0                                
+	v_accvgpr_write_b32 a137, 0                                
+	v_accvgpr_write_b32 a138, 0                                
+	v_accvgpr_write_b32 a139, 0                                
+	v_accvgpr_write_b32 a140, 0                                
+	v_accvgpr_write_b32 a141, 0                                
+	v_accvgpr_write_b32 a142, 0                                
+	v_accvgpr_write_b32 a143, 0                                
+	v_accvgpr_write_b32 a144, 0                                
+	v_accvgpr_write_b32 a145, 0                                
+	v_accvgpr_write_b32 a146, 0                                
+	v_accvgpr_write_b32 a147, 0                                
+	v_accvgpr_write_b32 a148, 0                                
+	v_accvgpr_write_b32 a149, 0                                
+	v_accvgpr_write_b32 a150, 0                                
+	v_accvgpr_write_b32 a151, 0                                
+	v_accvgpr_write_b32 a152, 0                                
+	v_accvgpr_write_b32 a153, 0                                
+	v_accvgpr_write_b32 a154, 0                                
+	v_accvgpr_write_b32 a155, 0                                
+	v_accvgpr_write_b32 a156, 0                                
+	v_accvgpr_write_b32 a157, 0                                
+	v_accvgpr_write_b32 a158, 0                                
+	v_accvgpr_write_b32 a159, 0                                
+	v_accvgpr_write_b32 a160, 0                                
+	v_accvgpr_write_b32 a161, 0                                
+	v_accvgpr_write_b32 a162, 0                                
+	v_accvgpr_write_b32 a163, 0                                
+	v_accvgpr_write_b32 a164, 0                                
+	v_accvgpr_write_b32 a165, 0                                
+	v_accvgpr_write_b32 a166, 0                                
+	v_accvgpr_write_b32 a167, 0                                
+	v_accvgpr_write_b32 a168, 0                                
+	v_accvgpr_write_b32 a169, 0                                
+	v_accvgpr_write_b32 a170, 0                                
+	v_accvgpr_write_b32 a171, 0                                
+	v_accvgpr_write_b32 a172, 0                                
+	v_accvgpr_write_b32 a173, 0                                
+	v_accvgpr_write_b32 a174, 0                                
+	v_accvgpr_write_b32 a175, 0                                
+	v_accvgpr_write_b32 a176, 0                                
+	v_accvgpr_write_b32 a177, 0                                
+	v_accvgpr_write_b32 a178, 0                                
+	v_accvgpr_write_b32 a179, 0                                
+	v_accvgpr_write_b32 a180, 0                                
+	v_accvgpr_write_b32 a181, 0                                
+	v_accvgpr_write_b32 a182, 0                                
+	v_accvgpr_write_b32 a183, 0                                
+	v_accvgpr_write_b32 a184, 0                                
+	v_accvgpr_write_b32 a185, 0                                
+	v_accvgpr_write_b32 a186, 0                                
+	v_accvgpr_write_b32 a187, 0                                
+	v_accvgpr_write_b32 a188, 0                                
+	v_accvgpr_write_b32 a189, 0                                
+	v_accvgpr_write_b32 a190, 0                                
+	v_accvgpr_write_b32 a191, 0                                
+	v_accvgpr_write_b32 a192, 0                                
+	v_accvgpr_write_b32 a193, 0                                
+	v_accvgpr_write_b32 a194, 0                                
+	v_accvgpr_write_b32 a195, 0                                
+	v_accvgpr_write_b32 a196, 0                                
+	v_accvgpr_write_b32 a197, 0                                
+	v_accvgpr_write_b32 a198, 0                                
+	v_accvgpr_write_b32 a199, 0                                
+	v_accvgpr_write_b32 a200, 0                                
+	v_accvgpr_write_b32 a201, 0                                
+	v_accvgpr_write_b32 a202, 0                                
+	v_accvgpr_write_b32 a203, 0                                
+	v_accvgpr_write_b32 a204, 0                                
+	v_accvgpr_write_b32 a205, 0                                
+	v_accvgpr_write_b32 a206, 0                                
+	v_accvgpr_write_b32 a207, 0                                
+	v_accvgpr_write_b32 a208, 0                                
+	v_accvgpr_write_b32 a209, 0                                
+	v_accvgpr_write_b32 a210, 0                                
+	v_accvgpr_write_b32 a211, 0                                
+	v_accvgpr_write_b32 a212, 0                                
+	v_accvgpr_write_b32 a213, 0                                
+	v_accvgpr_write_b32 a214, 0                                
+	v_accvgpr_write_b32 a215, 0                                
+	v_accvgpr_write_b32 a216, 0                                
+	v_accvgpr_write_b32 a217, 0                                
+	v_accvgpr_write_b32 a218, 0                                
+	v_accvgpr_write_b32 a219, 0                                
+	v_accvgpr_write_b32 a220, 0                                
+	v_accvgpr_write_b32 a221, 0                                
+	v_accvgpr_write_b32 a222, 0                                
+	v_accvgpr_write_b32 a223, 0                                
+	v_accvgpr_write_b32 a224, 0                                
+	v_accvgpr_write_b32 a225, 0                                
+	v_accvgpr_write_b32 a226, 0                                
+	v_accvgpr_write_b32 a227, 0                                
+	v_accvgpr_write_b32 a228, 0                                
+	v_accvgpr_write_b32 a229, 0                                
+	v_accvgpr_write_b32 a230, 0                                
+	v_accvgpr_write_b32 a231, 0                                
+	v_accvgpr_write_b32 a232, 0                                
+	v_accvgpr_write_b32 a233, 0                                
+	v_accvgpr_write_b32 a234, 0                                
+	v_accvgpr_write_b32 a235, 0                                
+	v_accvgpr_write_b32 a236, 0                                
+	v_accvgpr_write_b32 a237, 0                                
+	v_accvgpr_write_b32 a238, 0                                
+	v_accvgpr_write_b32 a239, 0                                
+	s_waitcnt vmcnt(16)                                        
+	s_barrier                                                  
+	ds_read_b128 v[8:11], v198                                 
+	ds_read_b128 v[16:19], v198 offset:64                      
+	ds_read_b128 v[12:15], v198 offset:512                     
+	ds_read_b128 v[20:23], v198 offset:576                     
+	ds_read_b32 v184, v201                                     
+	ds_read_b128 v[24:27], v198 offset:4224                    
+	ds_read_b128 v[32:35], v198 offset:4288                    
+	ds_read_b128 v[28:31], v198 offset:4736                    
+	ds_read_b128 v[36:39], v198 offset:4800                    
+	ds_read_b32 v185, v201 offset:256                          
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_nop 0                                                    
+	s_lshl_b32 s36, s36, 1                                     
+	s_mul_i32 s62, s48, 0x60                                   
+	s_mul_hi_u32 s63, s36, s62                                 
+	s_add_u32 s5, s5, s63                                      
+	s_mul_i32 s63, s36, s62                                    
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_mul_i32 s63, s47, 0x280                                  
+	s_lshl_b32 s63, s63, 1                                     
+	s_add_u32 s4, s4, s63                                      
+	s_addc_u32 s5, s5, 0                                       
+	s_sub_i32 s62, s43, s62                                    
+	s_cmp_lt_u32 s62, 0x60                                     
+	s_cselect_b32 s62, s62, 0x60                               
+	s_mul_i32 s62, s36, s62                                    
+	s_sub_i32 s6, s62, s63                                     
+	s_mov_b32 s7, 0x20000                                      
+	s_mul_i32 s62, s46, 0xa0                                   
+	s_lshl_b32 s62, s62, 1                                     
+	v_lshrrev_b32_e32 v4, 5, v0                                
+	v_mul_i32_i24_e32 v4, 16, v4                               
+	v_lshrrev_b32_e32 v5, 4, v0                                
+	v_and_b32_e32 v5, 1, v5                                    
+	v_mul_i32_i24_e32 v5, 32, v5                               
+	v_add_u32_e32 v4, v4, v5                                   
+	v_and_b32_e32 v5, 15, v0                                   
+	v_mul_lo_u32 v217, s36, v5                                 
+	v_add_u32_e32 v217, s62, v217                              
+	v_add_u32_e32 v217, v4, v217                               
+	s_cmp_lt_i32 s46, 2                                        
+	s_cbranch_scc0 label_0862                                  
+	
+label_039D:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v198 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:9024                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v186, v201 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[40:43], a[160:163], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[44:47], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[40:43], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[44:47], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[48:51], a[160:163], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[52:55], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[48:51], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[52:55], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[24:27], a[96:99], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[28:31], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[24:27], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[28:31], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[32:35], a[96:99], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[36:39], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[32:35], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[36:39], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[40:43], a[176:179], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[44:47], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[40:43], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[44:47], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[48:51], a[176:179], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[52:55], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[48:51], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[52:55], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[24:27], a[112:115], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[28:31], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[24:27], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[28:31], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[32:35], a[112:115], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[36:39], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[40:43], a[192:195], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[44:47], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[40:43], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[44:47], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[48:51], a[192:195], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[52:55], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[48:51], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[52:55], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[24:27], a[128:131], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[28:31], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[24:27], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[28:31], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[32:35], a[128:131], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[36:39], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[32:35], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[36:39], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[40:43], a[208:211], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[44:47], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[40:43], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[44:47], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[48:51], a[208:211], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[52:55], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[48:51], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[52:55], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[8:11], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[12:15], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[16:19], a[64:67], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[20:23], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[16:19], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[20:23], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[24:27], a[144:147], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[28:31], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[24:27], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[28:31], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[32:35], a[144:147], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[36:39], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[32:35], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[36:39], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v187, v201 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[40:43], a[224:227], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v199 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[44:47], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[40:43], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v199 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[44:47], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[48:51], a[224:227], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v199 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[52:55], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[48:51], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v199 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[52:55], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v188, v201 offset:1280                         
+	s_cbranch_scc0 label_0D27                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v199 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v199 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v199 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v199 offset:9024                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v189, v201 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[72:75], a[80:83], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[76:79], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[72:75], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[76:79], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[80:83], a[80:83], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[84:87], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[80:83], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[84:87], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v190, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v190, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	s_cmp_lt_u32 s63, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s67, s67, 0                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[72:75], a[96:99], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[76:79], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[72:75], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[76:79], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[80:83], a[96:99], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[84:87], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[80:83], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[84:87], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[72:75], a[112:115], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[76:79], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[72:75], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[76:79], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[80:83], a[112:115], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[84:87], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[80:83], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[84:87], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[88:91], a[192:195], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[92:95], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[88:91], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[92:95], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[96:99], a[192:195], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[100:103], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[96:99], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[100:103], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[88:91], a[208:211], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[92:95], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[88:91], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[92:95], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[96:99], a[208:211], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[100:103], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[96:99], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[100:103], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[56:59], a[64:67], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[60:63], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[56:59], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[60:63], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[64:67], a[64:67], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[68:71], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[64:67], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[68:71], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v198                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v198 offset:576                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v184, v201                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[88:91], a[224:227], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[92:95], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[88:91], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[92:95], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[96:99], a[224:227], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[100:103], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[96:99], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v198 offset:4800                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[100:103], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b32 v185, v201 offset:256                          
+	s_cbranch_scc0 label_0D27                                  
+	s_branch label_039D                                        
+	
+label_0862:
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[8:11], a[0:3], v190, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[12:15], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[40:43], v198 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[8:11], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[12:15], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[48:51], v198 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[16:19], a[0:3], v190, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[20:23], a[4:7], v190, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[44:47], v198 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[16:19], a[8:11], v190, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[20:23], a[12:15], v190, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[52:55], v198 offset:9024                    
+	ds_read_b32 v186, v201 offset:512                          
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[24:27], a[80:83], v190, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[28:31], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[24:27], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[28:31], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[32:35], a[80:83], v190, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[36:39], a[84:87], v190, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[32:35], a[88:91], v190, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[36:39], a[92:95], v190, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[40:43], a[160:163], v190, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[44:47], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[40:43], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[44:47], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[48:51], a[160:163], v190, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[52:55], a[164:167], v190, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[48:51], a[168:171], v190, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[52:55], a[172:175], v190, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[8:11], a[16:19], v191, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[12:15], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[8:11], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[12:15], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[16:19], a[16:19], v191, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[20:23], a[20:23], v191, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[16:19], a[24:27], v191, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[20:23], a[28:31], v191, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[24:27], a[96:99], v191, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[28:31], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[24:27], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[28:31], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[32:35], a[96:99], v191, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[36:39], a[100:103], v191, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[32:35], a[104:107], v191, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[36:39], a[108:111], v191, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[40:43], a[176:179], v191, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[44:47], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[40:43], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[44:47], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[48:51], a[176:179], v191, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x400, s65                                   
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[52:55], a[180:183], v191, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[48:51], a[184:187], v191, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[52:55], a[188:191], v191, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[8:11], a[32:35], v192, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x3180, s64                                  
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[12:15], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[8:11], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x4200, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[12:15], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[16:19], a[32:35], v192, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[20:23], a[36:39], v192, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[16:19], a[40:43], v192, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[20:23], a[44:47], v192, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[24:27], a[112:115], v192, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[28:31], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[24:27], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[28:31], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[32:35], a[112:115], v192, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[36:39], a[116:119], v192, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[32:35], a[120:123], v192, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[36:39], a[124:127], v192, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[40:43], a[192:195], v192, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[44:47], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[40:43], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[44:47], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[48:51], a[192:195], v192, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[52:55], a[196:199], v192, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[48:51], a[200:203], v192, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[52:55], a[204:207], v192, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[8:11], a[48:51], v193, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x5280, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[12:15], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[8:11], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[12:15], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[16:19], a[48:51], v193, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[20:23], a[52:55], v193, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[16:19], a[56:59], v193, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[20:23], a[60:63], v193, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[24:27], a[128:131], v193, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[28:31], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[24:27], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[28:31], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[32:35], a[128:131], v193, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[36:39], a[132:135], v193, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[32:35], a[136:139], v193, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[36:39], a[140:143], v193, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[40:43], a[208:211], v193, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[44:47], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[40:43], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[44:47], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[48:51], a[208:211], v193, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[52:55], a[212:215], v193, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[48:51], a[216:219], v193, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[52:55], a[220:223], v193, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[8:11], a[64:67], v194, v184 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[12:15], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[8:11], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[12:15], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[16:19], a[64:67], v194, v184 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[20:23], a[68:71], v194, v184 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[16:19], a[72:75], v194, v184 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[20:23], a[76:79], v194, v184 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[24:27], a[144:147], v194, v185 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[28:31], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[56:59], v199                                
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[24:27], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[28:31], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[64:67], v199 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[32:35], a[144:147], v194, v185 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[36:39], a[148:151], v194, v185 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[60:63], v199 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[32:35], a[152:155], v194, v185 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[36:39], a[156:159], v194, v185 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[68:71], v199 offset:576                     
+	ds_read_b32 v187, v201 offset:1024                         
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[40:43], a[224:227], v194, v186 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[44:47], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[72:75], v199 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[40:43], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[44:47], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[80:83], v199 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[48:51], a[224:227], v194, v186 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[52:55], a[228:231], v194, v186 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[76:79], v199 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[48:51], a[232:235], v194, v186 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[52:55], a[236:239], v194, v186 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[84:87], v199 offset:4800                    
+	ds_read_b32 v188, v201 offset:1280                         
+	s_cbranch_scc0 label_0D27                                  
+	s_waitcnt vmcnt(10) lgkmcnt(5)                             
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[104:107], v[56:59], a[0:3], v190, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[152:155], v208, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[104:107], v[60:63], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[88:91], v199 offset:8448                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[108:111], v[56:59], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[108:111], v[60:63], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[96:99], v199 offset:8512                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[0:3], v[112:115], v[64:67], a[0:3], v190, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[156:159], v209, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[4:7], v[112:115], v[68:71], a[4:7], v190, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[92:95], v199 offset:8960                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[8:11], v[116:119], v[64:67], a[8:11], v190, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[12:15], v[116:119], v[68:71], a[12:15], v190, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[100:103], v199 offset:9024                  
+	ds_read_b32 v189, v201 offset:1536                         
+	s_waitcnt lgkmcnt(5)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[104:107], v[72:75], a[80:83], v190, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[160:163], v208, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[104:107], v[76:79], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[108:111], v[72:75], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[108:111], v[76:79], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], v[112:115], v[80:83], a[80:83], v190, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[164:167], v209, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[84:87], v[112:115], v[84:87], a[84:87], v190, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[88:91], v[116:119], v[80:83], a[88:91], v190, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[92:95], v[116:119], v[84:87], a[92:95], v190, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt lgkmcnt(0)                                       
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[104:107], v[88:91], a[160:163], v190, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v193, v215, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[104:107], v[92:95], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[108:111], v[88:91], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[108:111], v[92:95], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[160:163], v[112:115], v[96:99], a[160:163], v190, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[164:167], v[112:115], v[100:103], a[164:167], v190, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[168:171], v[116:119], v[96:99], a[168:171], v190, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[172:175], v[116:119], v[100:103], a[172:175], v190, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(10)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[120:123], v[56:59], a[16:19], v191, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s63, 0x100, s60                                  
+	buffer_load_dwordx4 v[168:171], v210, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[120:123], v[60:63], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_u32 s63, s61                                      
+	s_cselect_b32 s67, s67, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[124:127], v[56:59], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s69, s69, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[124:127], v[60:63], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[16:19], v[128:131], v[64:67], a[16:19], v191, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[172:175], v211, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[20:23], v[128:131], v[68:71], a[20:23], v191, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[24:27], v[132:135], v[64:67], a[24:27], v191, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[28:31], v[132:135], v[68:71], a[28:31], v191, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[120:123], v[72:75], a[96:99], v191, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[176:179], v210, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[120:123], v[76:79], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[124:127], v[72:75], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[124:127], v[76:79], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[96:99], v[128:131], v[80:83], a[96:99], v191, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[180:183], v211, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[100:103], v[128:131], v[84:87], a[100:103], v191, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[104:107], v[132:135], v[80:83], a[104:107], v191, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[108:111], v[132:135], v[84:87], a[108:111], v191, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[120:123], v[88:91], a[176:179], v191, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v194, v216, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[120:123], v[92:95], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s16, s16, s67                                    
+	s_addc_u32 s17, 0, s17                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[124:127], v[88:91], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_sub_u32 s18, s18, s67                                    
+	s_add_u32 s24, s24, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[124:127], v[92:95], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addc_u32 s25, 0, s25                                     
+	s_sub_u32 s26, s26, s69                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[176:179], v[128:131], v[96:99], a[176:179], v191, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s65                                       
+	buffer_load_dword v200, s[20:23], 0 offen lds              
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[180:183], v[128:131], v[100:103], a[180:183], v191, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[184:187], v[132:135], v[96:99], a[184:187], v191, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[188:191], v[132:135], v[100:103], a[188:191], v191, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(11)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[136:139], v[56:59], a[32:35], v192, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0, s64                                       
+	buffer_load_dwordx4 v195, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[136:139], v[60:63], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[140:143], v[56:59], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x1080, s64                                  
+	buffer_load_dwordx4 v196, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[140:143], v[60:63], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[32:35], v[144:147], v[64:67], a[32:35], v192, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[104:107], v202, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[36:39], v[144:147], v[68:71], a[36:39], v192, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[40:43], v[148:151], v[64:67], a[40:43], v192, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[44:47], v[148:151], v[68:71], a[44:47], v192, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[136:139], v[72:75], a[112:115], v192, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[108:111], v203, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[136:139], v[76:79], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[140:143], v[72:75], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[140:143], v[76:79], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[112:115], v[144:147], v[80:83], a[112:115], v192, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[112:115], v202, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[116:119], v[144:147], v[84:87], a[116:119], v192, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[120:123], v[148:151], v[80:83], a[120:123], v192, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[124:127], v[148:151], v[84:87], a[124:127], v192, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[136:139], v[88:91], a[192:195], v192, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[116:119], v203, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[136:139], v[92:95], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[140:143], v[88:91], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[140:143], v[92:95], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[192:195], v[144:147], v[96:99], a[192:195], v192, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v190, v212, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[196:199], v[144:147], v[100:103], a[196:199], v192, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[200:203], v[148:151], v[96:99], a[200:203], v192, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[204:207], v[148:151], v[100:103], a[204:207], v192, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[152:155], v[56:59], a[48:51], v193, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 m0, 0x2100, s64                                  
+	buffer_load_dwordx4 v197, s[12:15], 0 offen lds            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[152:155], v[60:63], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s62, 0x200, s60                                  
+	s_cmp_lt_u32 s62, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[156:159], v[56:59], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cselect_b32 s66, s66, 0                                  
+	s_cselect_b32 s68, s68, 0                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[156:159], v[60:63], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_add_u32 s12, s12, s66                                    
+	s_addc_u32 s13, 0, s13                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[48:51], v[160:163], v[64:67], a[48:51], v193, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s14, s14, s66                                    
+	buffer_load_dwordx4 v[120:123], v204, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[52:55], v[160:163], v[68:71], a[52:55], v193, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_add_u32 s20, s20, s68                                    
+	s_addc_u32 s21, 0, s21                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[56:59], v[164:167], v[64:67], a[56:59], v193, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_sub_u32 s22, s22, s68                                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[60:63], v[164:167], v[68:71], a[60:63], v193, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[152:155], v[72:75], a[128:131], v193, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[124:127], v205, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[152:155], v[76:79], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[156:159], v[72:75], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[156:159], v[76:79], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[128:131], v[160:163], v[80:83], a[128:131], v193, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[128:131], v204, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[132:135], v[160:163], v[84:87], a[132:135], v193, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[136:139], v[164:167], v[80:83], a[136:139], v193, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[140:143], v[164:167], v[84:87], a[140:143], v193, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[152:155], v[88:91], a[208:211], v193, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[132:135], v205, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[152:155], v[92:95], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[156:159], v[88:91], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[156:159], v[92:95], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[208:211], v[160:163], v[96:99], a[208:211], v193, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dword v191, v213, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[212:215], v[160:163], v[100:103], a[212:215], v193, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[216:219], v[164:167], v[96:99], a[216:219], v193, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[220:223], v[164:167], v[100:103], a[220:223], v193, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(14)                                        
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[168:171], v[56:59], a[64:67], v194, v187 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_addk_i32 s60, 0x100                                      
+	buffer_load_dwordx4 v[136:139], v206, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[168:171], v[60:63], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	s_cmp_lt_i32 s60, s61                                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[172:175], v[56:59], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[172:175], v[60:63], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[64:67], v[176:179], v[64:67], a[64:67], v194, v187 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[140:143], v207, s[16:19], 0 offen nt    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[68:71], v[176:179], v[68:71], a[68:71], v194, v187 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[72:75], v[180:183], v[64:67], a[72:75], v194, v187 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[76:79], v[180:183], v[68:71], a[76:79], v194, v187 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	s_waitcnt vmcnt(13)                                        
+	s_barrier                                                  
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[168:171], v[72:75], a[144:147], v194, v188 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[144:147], v206, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[168:171], v[76:79], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[8:11], v198                                 
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[172:175], v[72:75], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[172:175], v[76:79], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[16:19], v198 offset:64                      
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[144:147], v[176:179], v[80:83], a[144:147], v194, v188 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	buffer_load_dwordx4 v[148:151], v207, s[16:19], 0 offen offset:1024
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[148:151], v[176:179], v[84:87], a[148:151], v194, v188 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[12:15], v198 offset:512                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[152:155], v[180:183], v[80:83], a[152:155], v194, v188 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[156:159], v[180:183], v[84:87], a[156:159], v194, v188 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[20:23], v198 offset:576                     
+	ds_read_b32 v184, v201                                     
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[168:171], v[88:91], a[224:227], v194, v189 op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	buffer_load_dword v192, v214, s[24:27], 0 offen nt            
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[168:171], v[92:95], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[24:27], v198 offset:4224                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[172:175], v[88:91], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[172:175], v[92:95], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[0,0,0] cbsz:4 blgp:4
+	ds_read_b128 v[32:35], v198 offset:4288                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[224:227], v[176:179], v[96:99], a[224:227], v194, v189 op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[228:231], v[176:179], v[100:103], a[228:231], v194, v189 op_sel:[0,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[28:31], v198 offset:4736                    
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[232:235], v[180:183], v[96:99], a[232:235], v194, v189 op_sel:[1,0,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	v_mfma_scale_f32_16x16x128_f8f6f4 a[236:239], v[180:183], v[100:103], a[236:239], v194, v189 op_sel:[1,1,0] op_sel_hi:[1,1,0] cbsz:4 blgp:4
+	ds_read_b128 v[36:39], v198 offset:4800                    
+	ds_read_b32 v185, v201 offset:256                          
+	s_cbranch_scc0 label_0D27                                  
+	s_branch label_0862                                        
+	
+label_0D27:
+	s_waitcnt lgkmcnt(0)                                       
+	s_mul_i32 s62, s47, 0x280                                  
+	s_mul_i32 s63, s46, 0xa0                                   
+	s_add_u32 s60, s62, s63                                    
+	s_add_u32 s62, s60, 0xa0                                   
+	s_cmp_lt_i32 s44, s62                                      
+	s_cbranch_scc1 label_10FB                                  
+	s_mul_i32 s62, s36, 16                                     
+	v_add_u32_e32 v221, 0, v217                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 64, v217                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 0x80, v217                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 0xc0, v217                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_add_u32_e32 v221, 0x100, v217                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_branch label_14D3                                        
+	
+label_10FB:
+	s_mul_i32 s62, s36, 16                                     
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0, v217                                
+	v_accvgpr_read_b32 v8, a0                                  
+	v_accvgpr_read_b32 v9, a1                                  
+	v_accvgpr_read_b32 v10, a2                                 
+	v_accvgpr_read_b32 v11, a3                                 
+	v_accvgpr_read_b32 v12, a8                                 
+	v_accvgpr_read_b32 v13, a9                                 
+	v_accvgpr_read_b32 v14, a10                                
+	v_accvgpr_read_b32 v15, a11                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a4                                  
+	v_accvgpr_read_b32 v9, a5                                  
+	v_accvgpr_read_b32 v10, a6                                 
+	v_accvgpr_read_b32 v11, a7                                 
+	v_accvgpr_read_b32 v12, a12                                
+	v_accvgpr_read_b32 v13, a13                                
+	v_accvgpr_read_b32 v14, a14                                
+	v_accvgpr_read_b32 v15, a15                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a80                                 
+	v_accvgpr_read_b32 v9, a81                                 
+	v_accvgpr_read_b32 v10, a82                                
+	v_accvgpr_read_b32 v11, a83                                
+	v_accvgpr_read_b32 v12, a88                                
+	v_accvgpr_read_b32 v13, a89                                
+	v_accvgpr_read_b32 v14, a90                                
+	v_accvgpr_read_b32 v15, a91                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a84                                 
+	v_accvgpr_read_b32 v9, a85                                 
+	v_accvgpr_read_b32 v10, a86                                
+	v_accvgpr_read_b32 v11, a87                                
+	v_accvgpr_read_b32 v12, a92                                
+	v_accvgpr_read_b32 v13, a93                                
+	v_accvgpr_read_b32 v14, a94                                
+	v_accvgpr_read_b32 v15, a95                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a160                                
+	v_accvgpr_read_b32 v9, a161                                
+	v_accvgpr_read_b32 v10, a162                               
+	v_accvgpr_read_b32 v11, a163                               
+	v_accvgpr_read_b32 v12, a168                               
+	v_accvgpr_read_b32 v13, a169                               
+	v_accvgpr_read_b32 v14, a170                               
+	v_accvgpr_read_b32 v15, a171                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a164                                
+	v_accvgpr_read_b32 v9, a165                                
+	v_accvgpr_read_b32 v10, a166                               
+	v_accvgpr_read_b32 v11, a167                               
+	v_accvgpr_read_b32 v12, a172                               
+	v_accvgpr_read_b32 v13, a173                               
+	v_accvgpr_read_b32 v14, a174                               
+	v_accvgpr_read_b32 v15, a175                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 64, v217                               
+	v_accvgpr_read_b32 v8, a16                                 
+	v_accvgpr_read_b32 v9, a17                                 
+	v_accvgpr_read_b32 v10, a18                                
+	v_accvgpr_read_b32 v11, a19                                
+	v_accvgpr_read_b32 v12, a24                                
+	v_accvgpr_read_b32 v13, a25                                
+	v_accvgpr_read_b32 v14, a26                                
+	v_accvgpr_read_b32 v15, a27                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a20                                 
+	v_accvgpr_read_b32 v9, a21                                 
+	v_accvgpr_read_b32 v10, a22                                
+	v_accvgpr_read_b32 v11, a23                                
+	v_accvgpr_read_b32 v12, a28                                
+	v_accvgpr_read_b32 v13, a29                                
+	v_accvgpr_read_b32 v14, a30                                
+	v_accvgpr_read_b32 v15, a31                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a96                                 
+	v_accvgpr_read_b32 v9, a97                                 
+	v_accvgpr_read_b32 v10, a98                                
+	v_accvgpr_read_b32 v11, a99                                
+	v_accvgpr_read_b32 v12, a104                               
+	v_accvgpr_read_b32 v13, a105                               
+	v_accvgpr_read_b32 v14, a106                               
+	v_accvgpr_read_b32 v15, a107                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a100                                
+	v_accvgpr_read_b32 v9, a101                                
+	v_accvgpr_read_b32 v10, a102                               
+	v_accvgpr_read_b32 v11, a103                               
+	v_accvgpr_read_b32 v12, a108                               
+	v_accvgpr_read_b32 v13, a109                               
+	v_accvgpr_read_b32 v14, a110                               
+	v_accvgpr_read_b32 v15, a111                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a176                                
+	v_accvgpr_read_b32 v9, a177                                
+	v_accvgpr_read_b32 v10, a178                               
+	v_accvgpr_read_b32 v11, a179                               
+	v_accvgpr_read_b32 v12, a184                               
+	v_accvgpr_read_b32 v13, a185                               
+	v_accvgpr_read_b32 v14, a186                               
+	v_accvgpr_read_b32 v15, a187                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a180                                
+	v_accvgpr_read_b32 v9, a181                                
+	v_accvgpr_read_b32 v10, a182                               
+	v_accvgpr_read_b32 v11, a183                               
+	v_accvgpr_read_b32 v12, a188                               
+	v_accvgpr_read_b32 v13, a189                               
+	v_accvgpr_read_b32 v14, a190                               
+	v_accvgpr_read_b32 v15, a191                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0x80, v217                             
+	v_accvgpr_read_b32 v8, a32                                 
+	v_accvgpr_read_b32 v9, a33                                 
+	v_accvgpr_read_b32 v10, a34                                
+	v_accvgpr_read_b32 v11, a35                                
+	v_accvgpr_read_b32 v12, a40                                
+	v_accvgpr_read_b32 v13, a41                                
+	v_accvgpr_read_b32 v14, a42                                
+	v_accvgpr_read_b32 v15, a43                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a36                                 
+	v_accvgpr_read_b32 v9, a37                                 
+	v_accvgpr_read_b32 v10, a38                                
+	v_accvgpr_read_b32 v11, a39                                
+	v_accvgpr_read_b32 v12, a44                                
+	v_accvgpr_read_b32 v13, a45                                
+	v_accvgpr_read_b32 v14, a46                                
+	v_accvgpr_read_b32 v15, a47                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a112                                
+	v_accvgpr_read_b32 v9, a113                                
+	v_accvgpr_read_b32 v10, a114                               
+	v_accvgpr_read_b32 v11, a115                               
+	v_accvgpr_read_b32 v12, a120                               
+	v_accvgpr_read_b32 v13, a121                               
+	v_accvgpr_read_b32 v14, a122                               
+	v_accvgpr_read_b32 v15, a123                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a116                                
+	v_accvgpr_read_b32 v9, a117                                
+	v_accvgpr_read_b32 v10, a118                               
+	v_accvgpr_read_b32 v11, a119                               
+	v_accvgpr_read_b32 v12, a124                               
+	v_accvgpr_read_b32 v13, a125                               
+	v_accvgpr_read_b32 v14, a126                               
+	v_accvgpr_read_b32 v15, a127                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a192                                
+	v_accvgpr_read_b32 v9, a193                                
+	v_accvgpr_read_b32 v10, a194                               
+	v_accvgpr_read_b32 v11, a195                               
+	v_accvgpr_read_b32 v12, a200                               
+	v_accvgpr_read_b32 v13, a201                               
+	v_accvgpr_read_b32 v14, a202                               
+	v_accvgpr_read_b32 v15, a203                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a196                                
+	v_accvgpr_read_b32 v9, a197                                
+	v_accvgpr_read_b32 v10, a198                               
+	v_accvgpr_read_b32 v11, a199                               
+	v_accvgpr_read_b32 v12, a204                               
+	v_accvgpr_read_b32 v13, a205                               
+	v_accvgpr_read_b32 v14, a206                               
+	v_accvgpr_read_b32 v15, a207                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0xc0, v217                             
+	v_accvgpr_read_b32 v8, a48                                 
+	v_accvgpr_read_b32 v9, a49                                 
+	v_accvgpr_read_b32 v10, a50                                
+	v_accvgpr_read_b32 v11, a51                                
+	v_accvgpr_read_b32 v12, a56                                
+	v_accvgpr_read_b32 v13, a57                                
+	v_accvgpr_read_b32 v14, a58                                
+	v_accvgpr_read_b32 v15, a59                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a52                                 
+	v_accvgpr_read_b32 v9, a53                                 
+	v_accvgpr_read_b32 v10, a54                                
+	v_accvgpr_read_b32 v11, a55                                
+	v_accvgpr_read_b32 v12, a60                                
+	v_accvgpr_read_b32 v13, a61                                
+	v_accvgpr_read_b32 v14, a62                                
+	v_accvgpr_read_b32 v15, a63                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a128                                
+	v_accvgpr_read_b32 v9, a129                                
+	v_accvgpr_read_b32 v10, a130                               
+	v_accvgpr_read_b32 v11, a131                               
+	v_accvgpr_read_b32 v12, a136                               
+	v_accvgpr_read_b32 v13, a137                               
+	v_accvgpr_read_b32 v14, a138                               
+	v_accvgpr_read_b32 v15, a139                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a132                                
+	v_accvgpr_read_b32 v9, a133                                
+	v_accvgpr_read_b32 v10, a134                               
+	v_accvgpr_read_b32 v11, a135                               
+	v_accvgpr_read_b32 v12, a140                               
+	v_accvgpr_read_b32 v13, a141                               
+	v_accvgpr_read_b32 v14, a142                               
+	v_accvgpr_read_b32 v15, a143                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a208                                
+	v_accvgpr_read_b32 v9, a209                                
+	v_accvgpr_read_b32 v10, a210                               
+	v_accvgpr_read_b32 v11, a211                               
+	v_accvgpr_read_b32 v12, a216                               
+	v_accvgpr_read_b32 v13, a217                               
+	v_accvgpr_read_b32 v14, a218                               
+	v_accvgpr_read_b32 v15, a219                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a212                                
+	v_accvgpr_read_b32 v9, a213                                
+	v_accvgpr_read_b32 v10, a214                               
+	v_accvgpr_read_b32 v11, a215                               
+	v_accvgpr_read_b32 v12, a220                               
+	v_accvgpr_read_b32 v13, a221                               
+	v_accvgpr_read_b32 v14, a222                               
+	v_accvgpr_read_b32 v15, a223                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	s_cmp_lt_i32 s60, s44                                      
+	s_cbranch_scc0 label_14D3                                  
+	s_addk_i32 s60, 0x20                                       
+	v_add_u32_e32 v221, 0x100, v217                            
+	v_accvgpr_read_b32 v8, a64                                 
+	v_accvgpr_read_b32 v9, a65                                 
+	v_accvgpr_read_b32 v10, a66                                
+	v_accvgpr_read_b32 v11, a67                                
+	v_accvgpr_read_b32 v12, a72                                
+	v_accvgpr_read_b32 v13, a73                                
+	v_accvgpr_read_b32 v14, a74                                
+	v_accvgpr_read_b32 v15, a75                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a68                                 
+	v_accvgpr_read_b32 v9, a69                                 
+	v_accvgpr_read_b32 v10, a70                                
+	v_accvgpr_read_b32 v11, a71                                
+	v_accvgpr_read_b32 v12, a76                                
+	v_accvgpr_read_b32 v13, a77                                
+	v_accvgpr_read_b32 v14, a78                                
+	v_accvgpr_read_b32 v15, a79                                
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a144                                
+	v_accvgpr_read_b32 v9, a145                                
+	v_accvgpr_read_b32 v10, a146                               
+	v_accvgpr_read_b32 v11, a147                               
+	v_accvgpr_read_b32 v12, a152                               
+	v_accvgpr_read_b32 v13, a153                               
+	v_accvgpr_read_b32 v14, a154                               
+	v_accvgpr_read_b32 v15, a155                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a148                                
+	v_accvgpr_read_b32 v9, a149                                
+	v_accvgpr_read_b32 v10, a150                               
+	v_accvgpr_read_b32 v11, a151                               
+	v_accvgpr_read_b32 v12, a156                               
+	v_accvgpr_read_b32 v13, a157                               
+	v_accvgpr_read_b32 v14, a158                               
+	v_accvgpr_read_b32 v15, a159                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a224                                
+	v_accvgpr_read_b32 v9, a225                                
+	v_accvgpr_read_b32 v10, a226                               
+	v_accvgpr_read_b32 v11, a227                               
+	v_accvgpr_read_b32 v12, a232                               
+	v_accvgpr_read_b32 v13, a233                               
+	v_accvgpr_read_b32 v14, a234                               
+	v_accvgpr_read_b32 v15, a235                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	v_accvgpr_read_b32 v8, a228                                
+	v_accvgpr_read_b32 v9, a229                                
+	v_accvgpr_read_b32 v10, a230                               
+	v_accvgpr_read_b32 v11, a231                               
+	v_accvgpr_read_b32 v12, a236                               
+	v_accvgpr_read_b32 v13, a237                               
+	v_accvgpr_read_b32 v14, a238                               
+	v_accvgpr_read_b32 v15, a239                               
+	v_cvt_pk_bf16_f32 v16, v8, v9                              
+	v_cvt_pk_bf16_f32 v17, v10, v11                            
+	v_cvt_pk_bf16_f32 v18, v12, v13                            
+	v_cvt_pk_bf16_f32 v19, v14, v15                            
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v16, v18                         
+	s_nop 1                                                    
+	v_permlane16_swap_b32_e32 v17, v19                         
+	s_nop 1                                                    
+	buffer_store_dwordx4 v[16:19], v221, s[4:7], 0 offen       
+	v_add_u32_e32 v221, s62, v221                              
+	
+label_14D3:
+	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)                    
+	s_endpgm                                                   
+
+// ===== Kernel Descriptor (generates .rodata) =====
+.rodata
+.p2align 6
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB
+  .amdhsa_next_free_vgpr 512
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_group_segment_fixed_size 163840
+  .amdhsa_accum_offset 256
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+
+// ===== AMDGPU Metadata =====
+.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .actual_access:  read_write
+        .address_space:  global
+        .name:           D
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         8
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           C
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         24
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           A
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         40
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           B
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         56
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           alpha
+        .offset:         64
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         68
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         72
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         76
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           beta
+        .offset:         80
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         84
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         88
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         92
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD0
+        .offset:         96
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         100
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         104
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         108
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideD1
+        .offset:         112
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         116
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         120
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         124
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC0
+        .offset:         128
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         132
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         136
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         140
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideC1
+        .offset:         144
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         148
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         152
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         156
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA0
+        .offset:         160
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         164
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         168
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         172
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideA1
+        .offset:         176
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         180
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         184
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         188
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB0
+        .offset:         192
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         196
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         200
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         204
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideB1
+        .offset:         208
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         212
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         216
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         220
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Mdim
+        .offset:         224
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         228
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         232
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         236
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Ndim
+        .offset:         240
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         244
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         248
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         252
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           Kdim
+        .offset:         256
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         260
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         264
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         268
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleA
+        .offset:         272
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         280
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .actual_access:  read_only
+        .address_space:  global
+        .name:           ScaleB
+        .offset:         288
+        .size:           8
+        .value_kind:     global_buffer
+      - .name:           pad
+        .offset:         296
+        .size:           8
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA0
+        .offset:         304
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         308
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         312
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         316
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleA1
+        .offset:         320
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         324
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         328
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         332
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB0
+        .offset:         336
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         340
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         344
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         348
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           strideScaleB1
+        .offset:         352
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         356
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         360
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         364
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           log2_k_split
+        .offset:         368
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         372
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         376
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+      - .name:           pad
+        .offset:         380
+        .size:           4
+        .value_kind:     by_value
+        .value_type:     i32
+    .group_segment_fixed_size: 163840
+    .kernarg_segment_align: 4
+    .kernarg_segment_size: 384
+    .max_flat_workgroup_size: 256
+    .name:           f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB
+    .private_segment_fixed_size: 0
+    .reqd_workgroup_size:
+      - 256
+      - 1
+      - 1
+    .sgpr_count:     96
+    .symbol:         f4gemm_bf16_per1x32Fp4_BpreShuffle_96x640_ntB.kd
+    .vgpr_count:     512
+    .wavefront_size: 64
+amdhsa.version:
+  - 1
+  - 0
+...
+.end_amdgpu_metadata
+

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256.s
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels/f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256.s
@@ -10,11 +10,11 @@
 
 // ===== Kernel Code =====
 .text
-.globl _ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E
+.globl f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256
 .p2align 8
-.type _ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E,@function
+.type f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256,@function
 
-_ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E:
+f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256:
 	
 	s_and_b32 s1, s1, 0xffff                                   
 	s_load_dword s25, s[0:1], 0xe0                             
@@ -1829,7 +1829,7 @@ label_103F:
 // ===== Kernel Descriptor (generates .rodata) =====
 .rodata
 .p2align 6
-.amdhsa_kernel _ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E
+.amdhsa_kernel f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256
   .amdhsa_next_free_vgpr 512
   .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
   .amdhsa_group_segment_fixed_size 163840
@@ -2256,14 +2256,14 @@ amdhsa.kernels:
     .kernarg_segment_align: 4
     .kernarg_segment_size: 368
     .max_flat_workgroup_size: 256
-    .name:           _ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E
+    .name:           f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256
     .private_segment_fixed_size: 0
     .reqd_workgroup_size:
       - 256
       - 1
       - 1
     .sgpr_count:     96
-    .symbol:         _ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E.kd
+    .symbol:         f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256.kd
     .vgpr_count:     512
     .wavefront_size: 64
 amdhsa.version:

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/solution_selection.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/solution_selection.hpp
@@ -66,7 +66,9 @@ struct SolutionIndexParameters
     WorkGroupTileSize workgroupTile;
     bool              workgroupMapping;
     bool              streamK;
-    bool              tailLoops = true;
+    bool              tailLoops     = true;
+    bool              nonTemporalA  = false;
+    bool              nonTemporalB  = false;
 
     auto operator<=>(const SolutionIndexParameters& other) const = default;
 };

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
@@ -337,7 +337,7 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
             if(kernelType.swizzleA)
                 cu_multiplier = 4;
             if(numTiles * cu_multiplier < analytical_hardware.N_CU && itersPerTile >= 16
-               && !isF6 && !isLargeF8 && !is256Tile)
+               && !isF6 && !isLargeF8)
             {
                 useStreamK = true;
             }

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
@@ -45,14 +45,21 @@ constexpr std::array<WorkGroupTileSize, possibleSwizzleTileSizesCount> possibleS
         {224, 128, 128}, {224, 256, 128}, {256, 128, 128}, {256, 256, 128}}};
 
 // Helper to generate tile list from a compile-time known tile array
+// For each tile, generates 3 variants with different nontemporal settings:
+// 1. Both A and B non-temporal disabled (cache_hints_a=0, cache_hints_b=0)
+// 2. Only A non-temporal enabled (cache_hints_a=4, cache_hints_b=0)
+// 3. Only B non-temporal enabled (cache_hints_a=0, cache_hints_b=4)
+// Never generates configs where both are enabled simultaneously.
 template <rocRoller::DataType typeA,
           rocRoller::DataType typeB,
           size_t              TileCount,
           const std::array<WorkGroupTileSize, TileCount>& TileArray>
 std::vector<origami::config_t> generateTileListImpl(bool hasPreSwizzle, bool hasPreTile)
 {
+    // 3 variants per tile: (ntA=0,ntB=0), (ntA=1,ntB=0), (ntA=0,ntB=1)
+    constexpr size_t numNonTemporalVariants = 3;
     std::vector<origami::config_t> tileList;
-    tileList.reserve(TileCount);
+    tileList.reserve(TileCount * numNonTemporalVariants);
 
     for(size_t i = 0; i < TileCount; ++i)
     {
@@ -73,7 +80,9 @@ std::vector<origami::config_t> generateTileListImpl(bool hasPreSwizzle, bool has
 
         int unroll = preferredUnrolling(typeA, typeB, wgt, hasPreSwizzle, hasPreTile);
 
-        origami::config_t origami_config = {
+        // Generate 3 variants with different nontemporal settings
+        // Variant 1: Both disabled
+        origami::config_t config_both_off = {
             .mt = {static_cast<size_t>(wgt.m),
                    static_cast<size_t>(wgt.n),
                    static_cast<size_t>(wgtk * unroll)},
@@ -82,8 +91,31 @@ std::vector<origami::config_t> generateTileListImpl(bool hasPreSwizzle, bool has
             .cache_hints_a = 0,
             .cache_hints_b = 0,
         };
+        tileList.push_back(config_both_off);
 
-        tileList.push_back(origami_config);
+        // Variant 2: Only A non-temporal enabled
+        origami::config_t config_a_on = {
+            .mt = {static_cast<size_t>(wgt.m),
+                   static_cast<size_t>(wgt.n),
+                   static_cast<size_t>(wgtk * unroll)},
+            .mi = {static_cast<size_t>(MI.m), static_cast<size_t>(MI.n), static_cast<size_t>(MI.k)},
+            .occupancy     = 1,
+            .cache_hints_a = 4,
+            .cache_hints_b = 0,
+        };
+        tileList.push_back(config_a_on);
+
+        // Variant 3: Only B non-temporal enabled
+        origami::config_t config_b_on = {
+            .mt = {static_cast<size_t>(wgt.m),
+                   static_cast<size_t>(wgt.n),
+                   static_cast<size_t>(wgtk * unroll)},
+            .mi = {static_cast<size_t>(MI.m), static_cast<size_t>(MI.n), static_cast<size_t>(MI.k)},
+            .occupancy     = 1,
+            .cache_hints_a = 0,
+            .cache_hints_b = 4,
+        };
+        tileList.push_back(config_b_on);
     }
 
     return tileList;
@@ -315,14 +347,18 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
             if(useStreamK && wgt.m == 64 && wgt.n == 256)
                 continue;
 
+            // Extract nontemporal hints from the config
+            bool useNonTemporalA = (result.config.cache_hints_a != 0);
+            bool useNonTemporalB = (result.config.cache_hints_b != 0);
+
             // Prefer assembly kernels for swizzleA
             if(kernelType.swizzleA && !useStreamK && ((wgt.m == 32 && wgt.n == 32) ||
                                                       (wgt.m == 64 && wgt.n == 32) ||
                                                       (wgt.m == 64 && wgt.n == 64) ||
                                                       (wgt.m == 128 && wgt.n == 32)))
-                lastParams.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops});
+                lastParams.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops, useNonTemporalA, useNonTemporalB});
             else
-                params.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops});
+                params.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops, useNonTemporalA, useNonTemporalB});
         }
     }
 
@@ -348,6 +384,10 @@ int parametersToIndex(const SolutionIndexParameters& params)
     result |= ((params.streamK ? 1 : 0) << pos);
     pos += 1;
     result |= ((params.tailLoops ? 1 : 0) << pos);
+    pos += 1;
+    result |= ((params.nonTemporalA ? 1 : 0) << pos);
+    pos += 1;
+    result |= ((params.nonTemporalB ? 1 : 0) << pos);
 
     // Set top bit indicating it is a rocRoller index
     result |= (1 << 31);
@@ -381,6 +421,10 @@ SolutionIndexParameters indexToParameters(int index)
     result.streamK = (index >> pos) & 1;
     pos += 1;
     result.tailLoops = (index >> pos) & 1;
+    pos += 1;
+    result.nonTemporalA = (index >> pos) & 1;
+    pos += 1;
+    result.nonTemporalB = (index >> pos) & 1;
 
     return result;
 }


### PR DESCRIPTION
## Motivation

In order to achieve good performance for GEMMs that have small M but large N values (or vice versa), we need to set the non-temporal flag when doing loads.

## Technical Details

Origami already has the ability to choose what the non-temporal flags should be set to. This PR adds the infrastructure for doing this when going down the hipBLASLt-rocRoller path.

Created copies of all of the FP4 customer assembly files where either all A loads are using the "nt" flag, or all B loads are.

Set it so it won't try to use custom kernels when StreamK is selected.

Modified kernel names to make it easier to programmatically generate names.

AI (Claude) was used to help create this PR.

## Test Plan

Test performance on large dataset and ensure it is going up for expected problems and not regressing on other problems.

## Test Result

Performance improved as expected.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
